### PR TITLE
Update links to point to GitHub repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released yet
 
+- 2022-08-09: Update links to point to the new GitHub repository of the code.
 - 2022-08-09: Seperate workflow such that canary builds (builds using DuMuX master) are done independently of the normal CI tests.
 - 2022-08-05: Moved CI to GitHub and updated CI workflows. Docker images now use the root user default user. Several Docker images have been added.
 - 2022-08-04: Restructure repository to have a more logical directory structure. Code examples live in `examples/`. These codes are also used as tests. Reference data resides in `test/`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![build and test develop](https://github.com/precice/dumux-adapter/actions/workflows/buildandtest.yml/badge.svg)
 ![build and test develop with DuMuX masters](https://github.com/precice/dumux-adapter/actions/workflows/buildandtestdumuxmaster.yml/badge.svg)
 
-This repository provides a [DuMuX](https://dumux.org/)-specific adapter to couple to other codes using [preCICE](https://www.precice.org/). You can find the source code of this adapter [on the IWS GitLab](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice).
+This repository provides a [DuMuX](https://dumux.org/)-specific adapter to couple to other codes using [preCICE](https://www.precice.org/). You can find the source code of this adapter [on GitHub](https://github.com/precice/dumux-adapter). The source code of the adapter was formerly stored [in a repository on the IWS GitLab](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice).
 
 ## Structure of the repository
 
@@ -48,13 +48,13 @@ The DuMuX-preCICE adapter should build fine if DuMuX, preCICE and their dependen
 2. Download the DuMuX-preCICE adapter to the same directory as the DUNE modules and the `dumux` folder. At the moment there are no adapter releases, besides an outdated `v0.1` release, such the best way is to checkout the `develop` branch of the adapter.
 
     ```text
-    git clone -b develop https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice.git
+    git clone -b develop https://github.com/precice/dumux-adapter.git
     ```
 
     You can also try to clone the repository via SSH:
 
     ```text
-    git clone -b develop git@git.iws.uni-stuttgart.de:dumux-appl/dumux-precice.git
+    git clone -b develop git@github.com:precice/dumux-adapter.git
     ```
 
 3. Verify that the `dumux-precice` folder is in the same directory as the DUNE module folders and the `dumux` folder.
@@ -106,7 +106,7 @@ There are advanced ways of managing DUNE modules, e.g. using the environment var
 
 ### User documentation
 
-At the moment the documentation is provided by the API documentation (see below) as well as the test and example cases. If something is unclear or you would want something to be documented better, please open an [issue](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice/-/issues) and let us know.
+At the moment the documentation is provided by the API documentation (see below) as well as the test and example cases. If something is unclear or you would want something to be documented better, please open an [issue](https://github.com/precice/dumux-adapter/issues) and let us know.
 
 ### API documentation
 

--- a/doc/user/mkdocs.yml
+++ b/doc/user/mkdocs.yml
@@ -7,7 +7,7 @@ theme:
     accent: blue
 
 repo_name: dumux-appl/dumux-preCICE
-repo_url: https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice
+repo_url: https://github.com/precice/dumux-adapter
 
 markdown_extensions:
   - admonition

--- a/dumux-precice.pc.in
+++ b/dumux-precice.pc.in
@@ -9,7 +9,7 @@ DEPENDENCIES=@REQUIRES@
 Name: @PACKAGE_NAME@
 Version: @VERSION@
 Description: dumux-precice module
-URL: https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice
+URL: https://github.com/precice/dumux-adapter
 Requires: dumux
 Suggests: dune-subgrid
 Libs: -L${libdir}


### PR DESCRIPTION
## Description

All links referring to the old repository of the adapter on the IWS GitLab have been updated to the new GitHub URL.

## Checklist

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
- [x] I updated the documentation.
