### PR TITLE
Update examples for DuMuX 3.5 and newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released yet
 
+- 2022-08-12: Update examples to work with DuMuX releases newer than DuMuX 3.5.
 - 2022-08-12: Update CI to test with preCICE 2.5.0.
 - 2022-08-11: Updated documentation and removed it from readthedocs.
 - 2022-08-09: Remove GitLab-specific files like CI configuration.

--- a/examples/ff-pm/flow-over-cube-3d/1pspatialparams.hh
+++ b/examples/ff-pm/flow-over-cube-3d/1pspatialparams.hh
@@ -24,7 +24,11 @@
 #ifndef DUMUX_1P_TEST_SPATIALPARAMS_HH
 #define DUMUX_1P_TEST_SPATIALPARAMS_HH
 
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+#include <dumux/porousmediumflow/fvspatialparams1p.hh>
+#else
 #include <dumux/material/spatialparams/fv1p.hh>
+#endif
 
 namespace Dumux
 {
@@ -36,15 +40,29 @@ namespace Dumux
  */
 template<class FVGridGeometry, class Scalar>
 class OnePSpatialParams
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    : public FVPorousMediumFlowSpatialParamsOneP<
+          FVGridGeometry,
+          Scalar,
+          OnePSpatialParams<FVGridGeometry, Scalar>>
+#else
     : public FVSpatialParamsOneP<FVGridGeometry,
                                  Scalar,
                                  OnePSpatialParams<FVGridGeometry, Scalar>>
+#endif
 {
     using GridView = typename FVGridGeometry::GridView;
     using ParentType =
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+        FVPorousMediumFlowSpatialParamsOneP<
+            FVGridGeometry,
+            Scalar,
+            OnePSpatialParams<FVGridGeometry, Scalar>>;
+#else
         FVSpatialParamsOneP<FVGridGeometry,
                             Scalar,
                             OnePSpatialParams<FVGridGeometry, Scalar>>;
+#endif
 
     using Element = typename GridView::template Codim<0>::Entity;
     using GlobalPosition = typename Element::Geometry::GlobalCoordinate;
@@ -96,7 +114,7 @@ public:
      *
      * This problem assumes a temperature of 10 degrees Celsius.
      */
-    Scalar temperature(const GlobalPosition &globalPos) const
+    Scalar temperatureAtPos(const GlobalPosition &globalPos) const
     {
         return 273.15 + 10;  // 10°C
     }

--- a/examples/ff-pm/flow-over-cube-3d/CMakeLists.txt
+++ b/examples/ff-pm/flow-over-cube-3d/CMakeLists.txt
@@ -28,7 +28,7 @@ dumux_add_test(NAME dummytarget_to_build_pm_flow_over_cube_3d
 
 
 dumux_add_test(NAME test_ff_pm_flow_over_cube_3d
-              TARGET ff_flow_over_cube_3d pm_flow_over_cube_3d
+              TARGET ff_flow_over_cube_3d
               LABELS freeflow stokes precice darcy
               TIMEOUT 30
               CMAKE_GUARD HAVE_UMFPACK

--- a/examples/ff-pm/flow-over-cube-3d/main_ff-reversed.cc
+++ b/examples/ff-pm/flow-over-cube-3d/main_ff-reversed.cc
@@ -284,7 +284,11 @@ try {
         GetPropType<FreeFlowTypeTag, Properties::GridGeometry>;
     auto freeFlowGridGeometry =
         std::make_shared<FreeFlowGridGeometry>(freeFlowGridView);
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    freeFlowGridGeometry->update(freeFlowGridManager.grid().leafGridView());
+#else
     freeFlowGridGeometry->update();
+#endif
 
     // the problem (initial and boundary conditions)
     using FreeFlowProblem = GetPropType<FreeFlowTypeTag, Properties::Problem>;

--- a/examples/ff-pm/flow-over-cube-3d/main_pm-reversed.cc
+++ b/examples/ff-pm/flow-over-cube-3d/main_pm-reversed.cc
@@ -326,7 +326,11 @@ try {
     using DarcyGridGeometry =
         GetPropType<DarcyTypeTag, Properties::GridGeometry>;
     auto darcyGridGeometry = std::make_shared<DarcyGridGeometry>(darcyGridView);
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    darcyGridGeometry->update(darcyGridManager.grid().leafGridView());
+#else
     darcyGridGeometry->update();
+#endif
 
     using DarcyProblem = GetPropType<DarcyTypeTag, Properties::Problem>;
     auto darcyProblem = std::make_shared<DarcyProblem>(darcyGridGeometry);

--- a/examples/ff-pm/flow-over-cube-3d/pmproblem-reversed.hh
+++ b/examples/ff-pm/flow-over-cube-3d/pmproblem-reversed.hh
@@ -134,12 +134,14 @@ public:
      */
     // \{
 
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR < 5
     /*!
      * \brief Return the temperature within the domain in [K].
      *
      */
     Scalar temperature() const { return 273.15 + 10; }  // 10°C
     // \}
+#endif
 
     /*!
      * \name Boundary conditions

--- a/examples/ff-pm/flow-over-square-2d/1pspatialparams.hh
+++ b/examples/ff-pm/flow-over-square-2d/1pspatialparams.hh
@@ -24,7 +24,11 @@
 #ifndef DUMUX_1P_TEST_SPATIALPARAMS_HH
 #define DUMUX_1P_TEST_SPATIALPARAMS_HH
 
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+#include <dumux/porousmediumflow/fvspatialparams1p.hh>
+#else
 #include <dumux/material/spatialparams/fv1p.hh>
+#endif
 
 namespace Dumux
 {
@@ -36,15 +40,29 @@ namespace Dumux
  */
 template<class FVGridGeometry, class Scalar>
 class OnePSpatialParams
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    : public FVPorousMediumFlowSpatialParamsOneP<
+          FVGridGeometry,
+          Scalar,
+          OnePSpatialParams<FVGridGeometry, Scalar>>
+#else
     : public FVSpatialParamsOneP<FVGridGeometry,
                                  Scalar,
                                  OnePSpatialParams<FVGridGeometry, Scalar>>
+#endif
 {
     using GridView = typename FVGridGeometry::GridView;
     using ParentType =
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+        FVPorousMediumFlowSpatialParamsOneP<
+            FVGridGeometry,
+            Scalar,
+            OnePSpatialParams<FVGridGeometry, Scalar>>;
+#else
         FVSpatialParamsOneP<FVGridGeometry,
                             Scalar,
                             OnePSpatialParams<FVGridGeometry, Scalar>>;
+#endif
 
     using Element = typename GridView::template Codim<0>::Entity;
     using GlobalPosition = typename Element::Geometry::GlobalCoordinate;
@@ -96,7 +114,7 @@ public:
      *
      * This problem assumes a temperature of 10 degrees Celsius.
      */
-    Scalar temperature(const GlobalPosition &globalPos) const
+    Scalar temperatureAtPos(const GlobalPosition &globalPos) const
     {
         return 273.15 + 10;  // 10°C
     }

--- a/examples/ff-pm/flow-over-square-2d/CMakeLists.txt
+++ b/examples/ff-pm/flow-over-square-2d/CMakeLists.txt
@@ -67,7 +67,7 @@ set_tests_properties(test_ff_pm_part_flow_over_square_2d_si_st_second PROPERTIES
   ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR}/test:$ENV{PYTHONPATH})
 
 dumux_add_test(NAME test_ff_pm_part_flow_over_square_2d_pi_st
-              TARGET ff_flow_over_square_2d pm_flow_over_square_2d
+              TARGET ff_flow_over_square_2d
               LABELS freeflow stokes precice darcy
               TIMEOUT 30
               CMAKE_GUARD HAVE_UMFPACK
@@ -100,7 +100,7 @@ set_property(TEST test_ff_pm_part_flow_over_square_2d_pi_st APPEND PROPERTY DEPE
 ######################
 
 dumux_add_test(NAME test_ff_pm_part_flow_over_square_2d_si_ns_first
-              TARGET ff_flow_over_square_2d pm_flow_over_square_2d
+              TARGET ff_flow_over_square_2d
               LABELS freeflow navierstokes precice darcy
               TIMEOUT 60
               CMAKE_GUARD HAVE_UMFPACK
@@ -123,7 +123,7 @@ set_tests_properties(test_ff_pm_part_flow_over_square_2d_si_ns_first PROPERTIES
     ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR}/test:$ENV{PYTHONPATH})
 
 dumux_add_test(NAME test_ff_pm_part_flow_over_square_2d_si_ns_second
-    TARGET ff_flow_over_square_2d pm_flow_over_square_2d
+    TARGET ff_flow_over_square_2d
     LABELS freeflow darcy precice darcy
     TIMEOUT 60
     CMAKE_GUARD HAVE_UMFPACK
@@ -146,7 +146,7 @@ set_tests_properties(test_ff_pm_part_flow_over_square_2d_si_ns_second PROPERTIES
  ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR}/test:$ENV{PYTHONPATH})
 
 dumux_add_test(NAME test_ff_pm_part_flow_over_square_2d_pi_ns
-              TARGET ff_flow_over_square_2d pm_flow_over_square_2d
+              TARGET ff_flow_over_square_2d
               LABELS freeflow navierstokes precice darcy
               TIMEOUT 60
               CMAKE_GUARD HAVE_UMFPACK

--- a/examples/ff-pm/flow-over-square-2d/main_ff.cc
+++ b/examples/ff-pm/flow-over-square-2d/main_ff.cc
@@ -182,7 +182,11 @@ try {
         GetPropType<FreeFlowTypeTag, Properties::GridGeometry>;
     auto freeFlowGridGeometry =
         std::make_shared<FreeFlowGridGeometry>(freeFlowGridView);
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    freeFlowGridGeometry->update(freeFlowGridManager.grid().leafGridView());
+#else
     freeFlowGridGeometry->update();
+#endif
 
     // the problem (initial and boundary conditions)
     using FreeFlowProblem = GetPropType<FreeFlowTypeTag, Properties::Problem>;

--- a/examples/ff-pm/flow-over-square-2d/main_pm.cc
+++ b/examples/ff-pm/flow-over-square-2d/main_pm.cc
@@ -226,7 +226,11 @@ try {
     using DarcyGridGeometry =
         GetPropType<DarcyTypeTag, Properties::GridGeometry>;
     auto darcyGridGeometry = std::make_shared<DarcyGridGeometry>(darcyGridView);
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR >= 5
+    darcyGridGeometry->update(darcyGridManager.grid().leafGridView());
+#else
     darcyGridGeometry->update();
+#endif
 
     using DarcyProblem = GetPropType<DarcyTypeTag, Properties::Problem>;
     auto darcyProblem = std::make_shared<DarcyProblem>(darcyGridGeometry);

--- a/examples/ff-pm/flow-over-square-2d/pmproblem-reversed.hh
+++ b/examples/ff-pm/flow-over-square-2d/pmproblem-reversed.hh
@@ -134,13 +134,14 @@ public:
      */
     // \{
 
+#if DUMUX_VERSION_MAJOR >= 3 & DUMUX_VERSION_MINOR < 5
     /*!
      * \brief Return the temperature within the domain in [K].
      *
      */
     Scalar temperature() const { return 273.15 + 10; }  // 10°C
     // \}
-
+#endif
     /*!
      * \name Boundary conditions
      */


### PR DESCRIPTION
## Description

This fixes the deprecation warnings that show up with DuMuX 3.5 and the compilation errors with DuMuX 3.6git. It also fixes some warnings issued by dunecontrol due to wrong test declarations.

## Checklist

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
