### PR TITLE
Trigger Docker container rebuild process when GitHub Action  is updated

### DIFF
--- a/.github/workflows/builddockercontainers.yml
+++ b/.github/workflows/builddockercontainers.yml
@@ -7,6 +7,7 @@ on:
       - develop
     paths:
       - 'docker/**'
+      - '.github/workflows/builddockercontainers.yml'
 
 jobs:
   build-and-release-docker-image:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released yet
 
+- 2022-08-12: Update CI config to rebuild Docker containers if Docker recips have been updated or when the CI config for building the containers has been updated.
 - 2022-08-12: Update examples to work with DuMuX releases newer than DuMuX 3.5.
 - 2022-08-12: Update CI to test with preCICE 2.5.0.
 - 2022-08-11: Updated documentation and removed it from readthedocs.


### PR DESCRIPTION
## Description

Makes sure that Docker containers are also rebuild in case the GitHub Action to build the containers is updated.

## Checklist

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
