### PR TITLE
Use Docker containers from preCICE namespace

### DIFF
--- a/.github/workflows/build-and-test-dumux-master.yml
+++ b/.github/workflows/build-and-test-dumux-master.yml
@@ -14,7 +14,7 @@ jobs:
         precice_version: [2.4.0, 2.5.0]
         dune_version: [2.8]
     container:
-      image: ajaust/dune-precice:${{ matrix.dune_version }}-${{ matrix.precice_version }}
+      image: precice/dune-precice:${{ matrix.dune_version }}-${{ matrix.precice_version }}
     runs-on: ubuntu-latest
     steps:
     - name: Print python3 version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
         dumux_version: [3.4, 3.5]
         precice_version: [2.3.0, 2.4.0, 2.5.0]
     container:
-      image: ajaust/dumux-precice:${{ matrix.dumux_version }}-${{ matrix.precice_version }}
+      image: precice/dumux-precice:${{ matrix.dumux_version }}-${{ matrix.precice_version }}
     runs-on: ubuntu-latest
     steps:
     - name: Print python3 version

--- a/.github/workflows/build-docker-containers.yml
+++ b/.github/workflows/build-docker-containers.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         dumux_version: [3.4, 3.5]
-        precice_version: [2.3.0, 2.4.0]
+        precice_version: [2.3.0, 2.4.0, 2.5.0]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -40,4 +40,34 @@ jobs:
             DUNE_VERSION=2.8
             PRECICEUBUNTU=focal
             DUMUX_VERSION=${{ matrix.dumux_version }}
+            PRECICE_VERSION=${{ matrix.precice_version }}
+  build-dune-precice:
+    name: Builds a Docker container for testing the DuMuX preCICE adapter (DUNE and preCICE)
+    runs-on: ubuntu-latest
+    env:
+        dockerhub_username: precice
+    strategy:
+      matrix:
+        dune_version: [2.8]
+        precice_version: [2.4.0, 2.5.0]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.dockerhub_username }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Dockerfile
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: "{{defaultContext}}:docker"
+          file: "./dockerfile_dune-precice.slim"
+          tags: ${{ env.dockerhub_username }}/dune-precice:${{ matrix.dune_version }}-${{ matrix.precice_version }}
+          build-args: |
+            DUNE_VERSION=#{{ matrix.dune_version }}
+            PRECICEUBUNTU=focal
             PRECICE_VERSION=${{ matrix.precice_version }}

--- a/.github/workflows/build-docker-containers.yml
+++ b/.github/workflows/build-docker-containers.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         dune_version: [2.8]
-        precice_version: [2.4.0, 2.5.0]
+        precice_version: [2.3.0, 2.4.0, 2.5.0]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/style-checking.yml
+++ b/.github/workflows/style-checking.yml
@@ -27,9 +27,9 @@ jobs:
         run: black --check .
   cpp_linting:
     runs-on: ubuntu-latest
-    container:
-      image: ajaust/style-check-github:0.3
     steps:
       - uses: actions/checkout@v2
       - name: Run format check
-        run: ./scripts/format/run-clang-format.sh
+        run: |
+          sudo apt-get install clang-format-10
+          ./scripts/format/run-clang-format.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released yet
 
+- 2022-09-14: Updated CI to use containers from `precice` namespace on DockerHub. Also makes sure that `dune-precice` containers are build for tests against DuMuX's master branch.
 - 2022-09-14: Updated and fixed GitHub to build Docker containers.
 - 2022-08-12: Update CI config to rebuild Docker containers if Docker recips have been updated or when the CI config for building the containers has been updated.
 - 2022-08-12: Update examples to work with DuMuX releases newer than DuMuX 3.5.

--- a/docker/rebuild-docker-images.sh
+++ b/docker/rebuild-docker-images.sh
@@ -7,14 +7,14 @@ PRECICE_VERSIONS=("2.4.0" "2.3.0")
 for dumux_version in ${DUMUX_VERSIONS[@]}; do
     for precice_version in ${PRECICE_VERSIONS[@]}; do
         echo "Building dumux-precice:${dumux_version}-${precice_version}"
-        docker build --build-arg DUNEVERSION=${DUNE_VERSION} --build-arg DUMUXVERSION=${dumux_version} --build-arg PRECICEVERSION=${precice_version} -t ajaust/dumux-precice:${dumux_version}-${precice_version} --file dockerfile.slim .
-        docker push ajaust/dumux-precice:${dumux_version}-${precice_version}
+        docker build --build-arg DUNEVERSION=${DUNE_VERSION} --build-arg DUMUXVERSION=${dumux_version} --build-arg PRECICEVERSION=${precice_version} -t precice/dumux-precice:${dumux_version}-${precice_version} --file dockerfile.slim .
+        docker push precice/dumux-precice:${dumux_version}-${precice_version}
         yes | docker image prune
     done
 done
 
 PRECICE_VERSION="2.4.0"
 echo "Building dune-precice:${dumux_version}-${precice_version}"
-docker build --build-arg DUNEVERSION=${DUNE_VERSION} --build-arg PRECICEVERSION=${PRECICE_VERSION} -t ajaust/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION} --file dockerfile_dune-precice.slim .
-docker push ajaust/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION}
+docker build --build-arg DUNEVERSION=${DUNE_VERSION} --build-arg PRECICEVERSION=${PRECICE_VERSION} -t precice/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION} --file dockerfile_dune-precice.slim .
+docker push precice/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION}
 yes | docker image prune


### PR DESCRIPTION
## Description

Updates CI to use Docker containers from `precice` namespace on Dockerhub. This also adds `dune-precice` to the containers being built on GitHub.

## Checklist

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
