### PR TITLE
Modifying docker container recipes to build with `precice:develop`

### DIFF
--- a/.github/workflows/build-docker-containers.yml
+++ b/.github/workflows/build-docker-containers.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         dumux_version: [3.4, 3.5]
-        precice_version: [2.3.0, 2.4.0, 2.5.0]
+        precice_version: [develop]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         dune_version: [2.9]
-        precice_version: [2.5.0]
+        precice_version: [develop]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/docker/dockerfile.slim
+++ b/docker/dockerfile.slim
@@ -35,7 +35,7 @@ ARG PRECICEVERSION=develop
 ARG PRECICEUBUNTU=focal
 RUN git clone --depth 1 -b ${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
 
-RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev && binprecice md
+RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev
 
 # Cleanup
 RUN apt-get autoremove -y && apt-get clean

--- a/docker/dockerfile.slim
+++ b/docker/dockerfile.slim
@@ -30,9 +30,10 @@ ENV DUNE_CONTROL_PATH=${DUMUXINSTALLPATH}/dune-common/dune.module:${DUMUXINSTALL
 ENV PYTHONPATH ${DUMUXINSTALLPATH}/dumux/bin/testing:${PYTHONPATH}
 
 # Compile minmum version of preCICE
-ARG PRECICEVERSION=2.4.0
+#ARG PRECICEVERSION=2.4.0
+ARG PRECICEVERSION=develop
 ARG PRECICEUBUNTU=focal
-RUN git clone --depth 1 -b v${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
+RUN git clone --depth 1 -b ${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
 
 RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev && binprecice md
 

--- a/docker/dockerfile_dune-precice.slim
+++ b/docker/dockerfile_dune-precice.slim
@@ -32,7 +32,7 @@ ARG PRECICEVERSION=develop
 ARG PRECICEUBUNTU=focal
 RUN git clone --depth 1 -b ${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
 
-RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev && binprecice md
+RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev
 
 # Cleanup
 RUN apt-get autoremove -y && apt-get clean

--- a/docker/dockerfile_dune-precice.slim
+++ b/docker/dockerfile_dune-precice.slim
@@ -27,9 +27,10 @@ RUN dunecontrol --opts=cmake-test.opts all
 ENV DUNE_CONTROL_PATH=${DUMUXINSTALLPATH}/dune-common/dune.module:${DUMUXINSTALLPATH}/dune-geometry/dune.module:${DUMUXINSTALLPATH}/dune-grid/dune.module:${DUMUXINSTALLPATH}/dune-localfunctions/dune.module:${DUMUXINSTALLPATH}/dune-istl/dune.module:${DUMUXINSTALLPATH}/dune-subgrid/dune.module
 
 # Compile minmum version of preCICE
-ARG PRECICEVERSION=2.4.0
+#ARG PRECICEVERSION=2.4.0
+ARG PRECICEVERSION=develop
 ARG PRECICEUBUNTU=focal
-RUN git clone --depth 1 -b v${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
+RUN git clone --depth 1 -b ${PRECICEVERSION} https://github.com/precice/precice.git precice-${PRECICEVERSION} && cd precice-${PRECICEVERSION} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEVERSION}
 
 RUN apt-get purge -y libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libxml2-dev && binprecice md
 

--- a/docker/rebuild-docker-images.sh
+++ b/docker/rebuild-docker-images.sh
@@ -2,7 +2,7 @@
 
 DUNE_VERSION="2.8"
 DUMUX_VERSIONS=("3.4" "3.5")
-PRECICE_VERSIONS=("2.4.0" "2.3.0")
+PRECICE_VERSIONS=("develop")
 
 for dumux_version in ${DUMUX_VERSIONS[@]}; do
     for precice_version in ${PRECICE_VERSIONS[@]}; do
@@ -13,7 +13,7 @@ for dumux_version in ${DUMUX_VERSIONS[@]}; do
     done
 done
 
-PRECICE_VERSION="2.4.0"
+PRECICE_VERSION="develop"
 echo "Building dune-precice:${dumux_version}-${precice_version}"
 docker build --build-arg DUNEVERSION=${DUNE_VERSION} --build-arg PRECICEVERSION=${PRECICE_VERSION} -t precice/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION} --file dockerfile_dune-precice.slim .
 docker push precice/dune-precice:${DUNE_VERSION}-${PRECICE_VERSION}


### PR DESCRIPTION
## Description

The idea is to change the Docker recipe to build containers with different DuMux versions and [precice:develop](https://github.com/precice/precice/tree/develop). These containers are necessary to test https://github.com/precice/dumux-adapter/pull/25.

## Checklist

- [x] I updated the documentation.