### PR TITLE
Remove outdated tag in the `dummytest` configuration file 

### DIFF
--- a/examples/dummysolver/precice-dummy-solver-config.xml
+++ b/examples/dummysolver/precice-dummy-solver-config.xml
@@ -56,8 +56,6 @@
       <max-time-windows value="2" />
       <time-window-size value="1.0" />
       <max-iterations value="2" />
-      <min-iteration-convergence-measure min-iterations="5" data="scalarDataOne" mesh="MeshOne"/>
-      <min-iteration-convergence-measure min-iterations="5" data="vectorDataOne" mesh="MeshOne"/>
 
       <exchange data="scalarDataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
       <exchange data="vectorDataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />


### PR DESCRIPTION
## Description
The `min-iteration-convergence-measure` has been removed in preCICE latest version. The `dummytest` needs to be updated accordingly. The test will run until the `max-iterations` is reached.

## Checklist

<!--
Please make sure to go over all points on the checklist and
mark them as checked.
-->

- [x] I made sure that the source files are formatted properly.