### PR TITLE
Remove www prefix from precice.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![build and test develop](https://github.com/precice/dumux-adapter/actions/workflows/build-and-test.yml/badge.svg)
 ![build and test develop with DuMuX masters](https://github.com/precice/dumux-adapter/actions/workflows/build-and-test-dumux-master.yml/badge.svg)
 
-This repository provides a [DuMuX](https://dumux.org/)-specific adapter to couple to other codes using [preCICE](https://www.precice.org/). The source code of the adapter was formerly stored [in a repository on the IWS GitLab](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice).
+This repository provides a [DuMuX](https://dumux.org/)-specific adapter to couple to other codes using [preCICE](https://precice.org/). The source code of the adapter was formerly stored [in a repository on the IWS GitLab](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice).
 
 ## Documentation
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ keywords: DuMuX, DUNE, C++
 summary: A DuMuX-specific DUNE module for coupling to other codes with preCICE.
 ---
 
-This is a [DuMuX](https://dumux.org/) adapter (a DUNE module specific to DuMuX) to couple to other codes using [preCICE](https://www.precice.org/). You can find the source code of this adapter [on GitHub](https://github.com/precice/dumux-adapter).
+This is a [DuMuX](https://dumux.org/) adapter (a DUNE module specific to DuMuX) to couple to other codes using [preCICE](https://precice.org/). You can find the source code of this adapter [on GitHub](https://github.com/precice/dumux-adapter).
 
 [Get](adapter-dumux-get.html) and [learn how to use](adapter-dumux-use.html) the adapter.
 


### PR DESCRIPTION
## Description

This PR removes the www prefix from precice org for the sake of consistency.
