### PR TITLE
Handle communication of coupling data for overlap cells in a parallel setting

### DIFF
--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -5,6 +5,8 @@
 #include <exception>
 #include <limits>
 
+#include <dune/common/parallel/mpihelper.hh>
+
 using namespace Dumux::Precice;
 
 CouplingAdapter::CouplingAdapter()
@@ -52,6 +54,26 @@ int CouplingAdapter::getMeshDimensions(const std::string &meshName) const
 {
     assert(wasCreated_);
     return precice_->getMeshDimensions(meshName);
+}
+
+
+void CouplingAdapter::setMesh(const std::string &meshName,
+                              const std::vector<double> &interiorPositions,
+                              const std::vector<double> &overlapPositions)
+{
+    assert(wasCreated_);
+    vertexIDs_ = std::vector<int>((interiorPositions.size() + overlapPositions.size()) /
+            getMeshDimensions(meshName));
+    numInteriorVertices_ = interiorPositions.size()/getMeshDimensions(meshName);
+    vertexIDsSpan_ = precice::span(vertexIDs_.data(), numInteriorVertices_);
+    precice_->setMeshVertices(meshName, interiorPositions, vertexIDsSpan_);
+    for (int i = numInteriorVertices_; i < vertexIDs_.size(); ++i)
+    {
+        vertexIDs_[i] = i;
+    }
+    // TODO: determine source ranks for overlap positions
+    auto mpiCommunication = Dune::MPIHelper::getCommunication();
+    meshWasCreated_ = true;
 }
 
 void CouplingAdapter::setMesh(const std::string &meshName,
@@ -202,16 +224,18 @@ void CouplingAdapter::readQuantityFromOtherSolver(const std::string &meshName,
                                                   const std::string &dataName,
                                                   double relativeReadTime)
 {
-    precice::span<double> dataValuesSpan(getQuantityVector(meshName, dataName));
+    precice::span<double> dataValuesSpan(getQuantityVector(meshName, dataName).data(),
+            numInteriorVertices_);
     precice_->readData(meshName, dataName, vertexIDsSpan_, relativeReadTime,
                        dataValuesSpan);
+    // TODO: read data for overlap from other ranks and write into back end of getQuantityVector
 }
 
 void CouplingAdapter::writeQuantityToOtherSolver(const std::string &meshName,
                                                  const std::string &dataName)
 {
     precice::span<const double> dataValuesSpan(
-        getQuantityVector(meshName, dataName));
+        getQuantityVector(meshName, dataName).data(), numInteriorVertices_);
     precice_->writeData(meshName, dataName, vertexIDsSpan_, dataValuesSpan);
 }
 

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -45,6 +45,8 @@ private:
     std::vector<int> vertexIDs_;  //should be size_t
     //! Span of the precice vertex indices vector vertexIDs_
     precice::span<precice::VertexID> vertexIDsSpan_;
+    //! Number of "interior" coupling points
+    int numInteriorVertices_;
     //! Constructor
     CouplingAdapter();
     /*!
@@ -139,7 +141,7 @@ public:
      *
      * @param[in] meshName The name of the mesh to add the vertices to.
      * @param[in] positions A span to the coordinates of the vertices.
-     * 
+     *
      * \note The coordinates need to be stored consecutively
      *       according to their spatial coordinates as.\n
      *       Example 2D:\n
@@ -149,6 +151,24 @@ public:
      */
     void setMesh(const std::string &meshName,
                  const std::vector<double> &positions);
+    /*!
+     * @brief Adds mesh for coupling of solvers. Positions are separated into interior and overlap
+     *        positions for parallel runs.
+     *
+     * @param[in] meshName The name of the mesh to add the vertices to.
+     * @param[in] interiorPositions A span to the coordinates of the interior vertices.
+     * @param[in] overlapPositions A span to the coordinates of the overlap vertices.
+     *
+     * \note The coordinates need to be stored consecutively
+     *       according to their spatial coordinates as.\n
+     *       Example 2D:\n
+     *       [x_1, y_1, x_2, y_2,...x_numPoints, y_numPoints]\n
+     *       Example 3D:\n
+     *       [x_1, y_1, z_1, x_2, y_2, z_2,...x_numPoints, y_numPoints, z_numPoints]
+     */
+    void setMesh(const std::string &meshName,
+                 const std::vector<double> &interiorPositions,
+                 const std::vector<double> &overlapPositions);
     /*!
      * @brief Initializes the coupling
      *


### PR DESCRIPTION
## Description

For parallel runs (MPI) each rank of the DuMux participant has only a local view of its own "interior" and some "overlap" elements. Each coupling point should only be registered with preCICE once and read/written from only one rank responsible for this coupling point. DuMux-adapter ranks use p2p MPI communication to obtain coupling data for coupling points in overlap elements.

- [ ] Interface to `setMesh` passing two lists of coordinate lists for interior and overlap points. Requires the user to sort coupling points into the two list and call `createIndexMapping` with a vector containing user-facing indices for all interior points, followed by overlap points.

TODO:
- [ ] Offer more user-friendly interface that also ensures alignment of coordinate list and user-facing-indices list.

## Checklist

<!--
Please make sure to go over all points on the checklist and
mark them as checked.
-->

- [ ] I made sure that the source files are formatted properly.
- [ ] I added my changes to the changelog (`CHANGELOG.md`)
- [ ] I updated the documentation.

<!--
If the pull request adds new content, please check the points
below. Otherwise remove the following lines.
-->

- [ ] I added a test for the new feature.
