### PR TITLE
Add dumux-customised checkpointing feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # DuMuX-preCICE change log
 
 ## latest
-
+- Added dumux-customised checkpointing feature [#58](https://github.com/precice/dumux-adapter/pull/58)
 - Improved ID lookup from `log(n)` to constant where n is the mesh size [#44](https://github.com/precice/dumux-adapter/pull/44)
 - Update DUNE version in the CI to 2.10 and update examples for compatibility [#45](https://github.com/precice/dumux-adapter/pull/45)
 

--- a/dumux-precice/CMakeLists.txt
+++ b/dumux-precice/CMakeLists.txt
@@ -2,5 +2,5 @@ install(FILES
 	couplingadapter.hh
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dumux-precice)
 
-dune_library_add_sources(dumux-precice SOURCES couplingadapter.cc dumuxpreciceindexmapper.cc)
+dune_library_add_sources(dumux-precice SOURCES couplingadapter.cc dumuxpreciceindexmapper.cc solverstate.cc)
 target_link_libraries(dumux-precice PRIVATE precice::precice)

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -208,12 +208,41 @@ bool CouplingAdapter::requiresToWriteInitialData()
 bool CouplingAdapter::requiresToReadCheckpoint()
 {
     assert(wasCreated_);
+    assert(checkpointingInitialized_);
     return precice_->requiresReadingCheckpoint();
 }
 
 bool CouplingAdapter::requiresToWriteCheckpoint()
 {
     assert(wasCreated_);
+    assert(checkpointingInitialized_);
     return precice_->requiresWritingCheckpoint();
 }
+
+bool CouplingAdapter::writeCheckpointIfRequired()
+{
+    if (!checkpointingInitialized_)
+        return false;
+    if (requiresToWriteCheckpoint() && !states_.empty()) {
+        for (auto &state : states_) {
+            state->writeState();
+        }
+        return true;
+    }
+    return false;
+}
+
+bool CouplingAdapter::readCheckpointIfRequired(double dt)
+{
+    if (!checkpointingInitialized_)
+        return false;
+    if (requiresToReadCheckpoint() && !states_.empty()) {
+        for (auto &state : states_) {
+            state->readState(dt);
+        }
+        return true;
+    }
+    return false;
+}
+
 CouplingAdapter::~CouplingAdapter() {}

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -205,23 +205,9 @@ bool CouplingAdapter::requiresToWriteInitialData()
     return precice_->requiresInitialData();
 }
 
-bool CouplingAdapter::requiresToReadCheckpoint()
-{
-    assert(wasCreated_);
-    assert(!states_.empty());
-    return precice_->requiresReadingCheckpoint();
-}
-
-bool CouplingAdapter::requiresToWriteCheckpoint()
-{
-    assert(wasCreated_);
-    assert(!states_.empty());
-    return precice_->requiresWritingCheckpoint();
-}
-
 bool CouplingAdapter::writeCheckpointIfRequired()
 {
-    if (!requiresToWriteCheckpoint()) {
+    if (!precice_->requiresWritingCheckpoint()) {
         return false;
     }
     for (auto &state : states_) {
@@ -232,7 +218,7 @@ bool CouplingAdapter::writeCheckpointIfRequired()
 
 bool CouplingAdapter::readCheckpointIfRequired()
 {
-    if (!requiresToReadCheckpoint()) {
+    if (!precice_->requiresReadingCheckpoint()) {
         return false;
     }
     for (auto &state : states_) {

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -207,6 +207,7 @@ bool CouplingAdapter::requiresToWriteInitialData()
 
 bool CouplingAdapter::writeCheckpointIfRequired()
 {
+    assert(wasCreated_);
     if (!precice_->requiresWritingCheckpoint()) {
         return false;
     }
@@ -218,6 +219,7 @@ bool CouplingAdapter::writeCheckpointIfRequired()
 
 bool CouplingAdapter::readCheckpointIfRequired()
 {
+    assert(wasCreated_);
     if (!precice_->requiresReadingCheckpoint()) {
         return false;
     }

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -221,24 +221,24 @@ bool CouplingAdapter::requiresToWriteCheckpoint()
 
 bool CouplingAdapter::writeCheckpointIfRequired()
 {
-    if (requiresToWriteCheckpoint() && !states_.empty()) {
-        for (auto &state : states_) {
-            state->writeState();
-        }
-        return true;
+    if (!requiresToWriteCheckpoint()) {
+        return false;
     }
-    return false;
+    for (auto &state : states_) {
+        state->writeState();
+    }
+    return true;
 }
 
 bool CouplingAdapter::readCheckpointIfRequired(double dt)
 {
-    if (requiresToReadCheckpoint() && !states_.empty()) {
-        for (auto &state : states_) {
-            state->readState(dt);
-        }
-        return true;
+    if (!requiresToReadCheckpoint()) {
+        return false;
     }
-    return false;
+    for (auto &state : states_) {
+        state->readState(dt);
+    }
+    return true;
 }
 
 CouplingAdapter::~CouplingAdapter() {}

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -208,14 +208,14 @@ bool CouplingAdapter::requiresToWriteInitialData()
 bool CouplingAdapter::requiresToReadCheckpoint()
 {
     assert(wasCreated_);
-    assert(checkpointingInitialized_);
+    assert(!states_.empty());
     return precice_->requiresReadingCheckpoint();
 }
 
 bool CouplingAdapter::requiresToWriteCheckpoint()
 {
     assert(wasCreated_);
-    assert(checkpointingInitialized_);
+    assert(!states_.empty());
     return precice_->requiresWritingCheckpoint();
 }
 

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -221,8 +221,6 @@ bool CouplingAdapter::requiresToWriteCheckpoint()
 
 bool CouplingAdapter::writeCheckpointIfRequired()
 {
-    if (!checkpointingInitialized_)
-        return false;
     if (requiresToWriteCheckpoint() && !states_.empty()) {
         for (auto &state : states_) {
             state->writeState();
@@ -234,8 +232,6 @@ bool CouplingAdapter::writeCheckpointIfRequired()
 
 bool CouplingAdapter::readCheckpointIfRequired(double dt)
 {
-    if (!checkpointingInitialized_)
-        return false;
     if (requiresToReadCheckpoint() && !states_.empty()) {
         for (auto &state : states_) {
             state->readState(dt);

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -230,13 +230,13 @@ bool CouplingAdapter::writeCheckpointIfRequired()
     return true;
 }
 
-bool CouplingAdapter::readCheckpointIfRequired(double dt)
+bool CouplingAdapter::readCheckpointIfRequired()
 {
     if (!requiresToReadCheckpoint()) {
         return false;
     }
     for (auto &state : states_) {
-        state->readState(dt);
+        state->readState();
     }
     return true;
 }

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -127,7 +127,9 @@ public:
      * @param[in] gv Grid variables
      */
     template<class SolutionVector, class GridVariables, class TimeLoop>
-    void initializeCheckpoint(SolutionVector &x, GridVariables &gv, TimeLoop &tl);
+    void initializeCheckpoint(SolutionVector &x,
+                              GridVariables &gv,
+                              TimeLoop &tl);
 
     template<class SolutionVector, class GridVariables>
     void initializeCheckpoint(SolutionVector &x, GridVariables &gv);
@@ -298,10 +300,13 @@ public:
 };
 
 template<class SolutionVector, class GridVariables, class TimeLoop>
-void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv, TimeLoop &tl)
+void CouplingAdapter::initializeCheckpoint(SolutionVector &x,
+                                           GridVariables &gv,
+                                           TimeLoop &tl)
 {
     states_.emplace_back(
-        std::make_unique<SolverStateGridVarTimeLoop<SolutionVector, GridVariables, TimeLoop>>(
+        std::make_unique<SolverStateGridVarTimeLoop<SolutionVector,
+                                                    GridVariables, TimeLoop>>(
             x, gv, tl));
 }
 

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "dumuxpreciceindexmapper.hh"
+#include "solverstate.hh"
 
 /*!
  * @brief Namespace of dumux-precice
@@ -40,6 +41,8 @@ private:
     bool meshWasCreated_;
     //! True if precice::Participant.initialize() has been called.
     bool preciceWasInitialized_;
+    //! True if checkpointing functionality has been initialized
+    bool checkpointingInitialized_{false};
     //! True if instance owns an instance of DumuxPreciceIndexMapper.
     bool hasIndexMapper_;
     //! Map storing meshName:dataName and data vectors
@@ -54,6 +57,21 @@ private:
      *
      */
     Internal::DumuxPreciceIndexMapper<FaceID, precice::VertexID> indexMapper_;
+    /*!
+     * @brief Store the state of the solver for checkpointing.
+     *
+     */
+    // std::unique_ptr<SolverStateBase> state_
+    std::vector<std::unique_ptr<SolverStateBase>> states_;
+
+    // Helper: add a new concrete SolverState instance
+    template<typename StateType, typename... Args>
+    void addState(Args &&...args)
+    {
+        states_.emplace_back(
+            std::make_unique<StateType>(std::forward<Args>(args)...));
+        checkpointingInitialized_ = true;
+    }
     /*!
      * @brief Get the number of quantities exchanged.
      *
@@ -126,6 +144,37 @@ public:
      * @return false No further action is needed.
      */
     bool requiresToWriteCheckpoint();
+
+    /*!
+     * @brief Initializes the checkpointing functionality.
+     *
+     * This function needs to be called at least once before using the checkpointing functionality.
+     *
+     * @param[in] x Solution vector
+     * @param[in] tl Timeloop
+     * @param[in] gv Grid variables
+     */
+    template<class SolutionVector, class TimeLoop, class GridVariables>
+    void initializeCheckpoint(SolutionVector &x,
+                              TimeLoop &tl,
+                              GridVariables &gv);
+
+    template<class SolutionVector, class GridVariables>
+    void initializeCheckpoint(SolutionVector &x, GridVariables &gv);
+
+    template<class SolutionVector>
+    void initializeCheckpoint(SolutionVector &x);
+    /*!
+     * @brief Writes the solver state to a checkpoint if required by preCICE.
+     *
+     */
+    bool writeCheckpointIfRequired();
+    /*!
+     * @brief Reads the solver state from a checkpoint if required by preCICE.
+     *
+     * @param[in] dt Time step size to set after reading the checkpoint
+     */
+    bool readCheckpointIfRequired(double dt);
 
     /*!
      * @brief Checks if the participant is required to provide initial data. If true, the participant needs to write initial data to defined vertices prior to calling initialize().
@@ -279,6 +328,27 @@ public:
      */
     void print(std::ostream &os);
 };
+
+template<class SolutionVector, class TimeLoop, class GridVariables>
+void CouplingAdapter::initializeCheckpoint(SolutionVector &x,
+                                           TimeLoop &tl,
+                                           GridVariables &gv)
+{
+    addState<SolverStateGridVarTime<SolutionVector, TimeLoop, GridVariables>>(
+        x, tl, gv);
+}
+
+template<class SolutionVector, class GridVariables>
+void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv)
+{
+    addState<SolverStateGridVar<SolutionVector, GridVariables>>(x, gv);
+}
+
+template<class SolutionVector>
+void CouplingAdapter::initializeCheckpoint(SolutionVector &x)
+{
+    addState<SolverStateOnly<SolutionVector>>(x);
+}
 
 }  // namespace Dumux::Precice
 #endif

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -126,6 +126,9 @@ public:
      * @param[in] x Solution vector
      * @param[in] gv Grid variables
      */
+    template<class SolutionVector, class GridVariables, class TimeLoop>
+    void initializeCheckpoint(SolutionVector &x, GridVariables &gv, TimeLoop &tl);
+
     template<class SolutionVector, class GridVariables>
     void initializeCheckpoint(SolutionVector &x, GridVariables &gv);
 
@@ -293,6 +296,14 @@ public:
      */
     void print(std::ostream &os);
 };
+
+template<class SolutionVector, class GridVariables, class TimeLoop>
+void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv, TimeLoop &tl)
+{
+    states_.emplace_back(
+        std::make_unique<SolverStateGridVarTimeLoop<SolutionVector, GridVariables, TimeLoop>>(
+            x, gv, tl));
+}
 
 template<class SolutionVector, class GridVariables>
 void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv)

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -58,10 +58,9 @@ private:
      */
     Internal::DumuxPreciceIndexMapper<FaceID, precice::VertexID> indexMapper_;
     /*!
-     * @brief Store the state of the solver for checkpointing.
+     * @brief Store the states of the solver for checkpointing.
      *
      */
-    // std::unique_ptr<SolverStateBase> state_
     std::vector<std::unique_ptr<SolverStateBase>> states_;
 
     // Helper: add a new concrete SolverState instance

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -125,6 +125,7 @@ public:
      *
      * @param[in] x Solution vector
      * @param[in] gv Grid variables
+     * @param[in] tl Time loop
      */
     template<class SolutionVector, class GridVariables, class TimeLoop>
     void initializeCheckpoint(SolutionVector &x,

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -139,14 +139,8 @@ public:
      * This function needs to be called at least once before using the checkpointing functionality.
      *
      * @param[in] x Solution vector
-     * @param[in] tl Timeloop
      * @param[in] gv Grid variables
      */
-    template<class SolutionVector, class TimeLoop, class GridVariables>
-    void initializeCheckpoint(SolutionVector &x,
-                              TimeLoop &tl,
-                              GridVariables &gv);
-
     template<class SolutionVector, class GridVariables>
     void initializeCheckpoint(SolutionVector &x, GridVariables &gv);
 
@@ -316,17 +310,6 @@ public:
      */
     void print(std::ostream &os);
 };
-
-template<class SolutionVector, class TimeLoop, class GridVariables>
-void CouplingAdapter::initializeCheckpoint(SolutionVector &x,
-                                           TimeLoop &tl,
-                                           GridVariables &gv)
-{
-    states_.emplace_back(
-        std::make_unique<
-            SolverStateGridVarTime<SolutionVector, TimeLoop, GridVariables>>(
-            x, tl, gv));
-}
 
 template<class SolutionVector, class GridVariables>
 void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv)

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -153,10 +153,8 @@ public:
     bool writeCheckpointIfRequired();
     /*!
      * @brief Reads the solver state from a checkpoint if required by preCICE.
-     *
-     * @param[in] dt Time step size to set after reading the checkpoint
      */
-    bool readCheckpointIfRequired(double dt);
+    bool readCheckpointIfRequired();
 
     /*!
      * @brief Checks if the participant is required to provide initial data. If true, the participant needs to write initial data to defined vertices prior to calling initialize().

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -41,8 +41,6 @@ private:
     bool meshWasCreated_;
     //! True if precice::Participant.initialize() has been called.
     bool preciceWasInitialized_;
-    //! True if checkpointing functionality has been initialized
-    bool checkpointingInitialized_{false};
     //! True if instance owns an instance of DumuxPreciceIndexMapper.
     bool hasIndexMapper_;
     //! Map storing meshName:dataName and data vectors
@@ -328,7 +326,6 @@ void CouplingAdapter::initializeCheckpoint(SolutionVector &x,
         std::make_unique<
             SolverStateGridVarTime<SolutionVector, TimeLoop, GridVariables>>(
             x, tl, gv));
-    checkpointingInitialized_ = true;
 }
 
 template<class SolutionVector, class GridVariables>
@@ -337,14 +334,12 @@ void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv)
     states_.emplace_back(
         std::make_unique<SolverStateGridVar<SolutionVector, GridVariables>>(
             x, gv));
-    checkpointingInitialized_ = true;
 }
 
 template<class SolutionVector>
 void CouplingAdapter::initializeCheckpoint(SolutionVector &x)
 {
     states_.emplace_back(std::make_unique<SolverStateOnly<SolutionVector>>(x));
-    checkpointingInitialized_ = true;
 }
 }  // namespace Dumux::Precice
 #endif

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -62,15 +62,6 @@ private:
      *
      */
     std::vector<std::unique_ptr<SolverStateBase>> states_;
-
-    // Helper: add a new concrete SolverState instance
-    template<typename StateType, typename... Args>
-    void addState(Args &&...args)
-    {
-        states_.emplace_back(
-            std::make_unique<StateType>(std::forward<Args>(args)...));
-        checkpointingInitialized_ = true;
-    }
     /*!
      * @brief Get the number of quantities exchanged.
      *
@@ -333,21 +324,27 @@ void CouplingAdapter::initializeCheckpoint(SolutionVector &x,
                                            TimeLoop &tl,
                                            GridVariables &gv)
 {
-    addState<SolverStateGridVarTime<SolutionVector, TimeLoop, GridVariables>>(
-        x, tl, gv);
+    states_.emplace_back(
+        std::make_unique<
+            SolverStateGridVarTime<SolutionVector, TimeLoop, GridVariables>>(
+            x, tl, gv));
+    checkpointingInitialized_ = true;
 }
 
 template<class SolutionVector, class GridVariables>
 void CouplingAdapter::initializeCheckpoint(SolutionVector &x, GridVariables &gv)
 {
-    addState<SolverStateGridVar<SolutionVector, GridVariables>>(x, gv);
+    states_.emplace_back(
+        std::make_unique<SolverStateGridVar<SolutionVector, GridVariables>>(
+            x, gv));
+    checkpointingInitialized_ = true;
 }
 
 template<class SolutionVector>
 void CouplingAdapter::initializeCheckpoint(SolutionVector &x)
 {
-    addState<SolverStateOnly<SolutionVector>>(x);
+    states_.emplace_back(std::make_unique<SolverStateOnly<SolutionVector>>(x));
+    checkpointingInitialized_ = true;
 }
-
 }  // namespace Dumux::Precice
 #endif

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -117,21 +117,6 @@ public:
      * @return double time step size
      */
     double getMaxTimeStepSize() const;
-    /*!
-     * @brief Checks if the participant is required to read an iteration checkpoint. If true, the participant is required to read an iteration checkpoint before calling advance().
-     *
-     * @return true Simulation checkpoint has to be restored.
-     * @return false No further action is needed.
-     */
-    bool requiresToReadCheckpoint();
-
-    /*!
-     * @brief Checks if the participant is required to write an iteration checkpoint. If true, the participant is required to write an iteration checkpoint before calling advance().
-     *
-     * @return true Simulation checkpoints needs to be stored.
-     * @return false No further action is needed.
-     */
-    bool requiresToWriteCheckpoint();
 
     /*!
      * @brief Initializes the checkpointing functionality.

--- a/dumux-precice/solverstate.cc
+++ b/dumux-precice/solverstate.cc
@@ -1,1 +1,1 @@
-# include "solverstate.hh"
+#include "solverstate.hh"

--- a/dumux-precice/solverstate.cc
+++ b/dumux-precice/solverstate.cc
@@ -1,0 +1,1 @@
+# include "solverstate.hh"

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -59,40 +59,5 @@ public:
         gv_->update(*x_);
     }
 };
-/*!
-    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
-    */
-template<class SolutionVector, class TimeLoop, class GridVariables>
-class SolverStateGridVarTime : public SolverStateBase
-{
-private:
-    SolutionVector *x_;
-    SolutionVector xCheckpoint_;
-    TimeLoop *tl_;
-    double timeCheckpoint_{0.0};
-    long timeStepCheckpoint_{0};
-    GridVariables *gv_;
-
-public:
-    SolverStateGridVarTime(SolutionVector &x, TimeLoop &tl, GridVariables &gv)
-        : x_(&x), xCheckpoint_(*x_), tl_(&tl), gv_(&gv)
-    {
-    }
-
-    void writeState() override
-    {
-        xCheckpoint_ = *x_;
-        timeCheckpoint_ = tl_->time();
-        timeStepCheckpoint_ = tl_->timeStepIndex();
-    }
-
-    void readState(double dt) override
-    {
-        *x_ = xCheckpoint_;
-        tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
-        tl_->setTimeStepSize(dt);
-        gv_->update(*x_);
-    }
-};
 }  // namespace Dumux::Precice
 #endif

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -1,0 +1,101 @@
+#ifndef SOLVERSTATE_HH
+#define SOLVERSTATE_HH
+
+#include <ostream>
+#include <string>
+#include <precice/precice.hpp>
+#include <dumux/common/properties.hh>
+
+/*!
+ * @brief Namespace of dumux-precice
+ *
+ */
+namespace Dumux::Precice
+{
+    struct SolverStateBase {
+        virtual ~SolverStateBase() = default;
+        virtual void writeState() = 0;
+        virtual void readState(double dt) = 0;
+    };
+    /*!
+    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+    */
+    template<class SolutionVector>
+    class SolverStateOnly: public SolverStateBase
+    {
+    private:
+        SolutionVector *x_;
+        SolutionVector xCheckpoint_;
+    public:
+        SolverStateOnly(SolutionVector &x)
+            : x_(&x), xCheckpoint_(*x_)
+        {}
+
+        void writeState() override {
+            xCheckpoint_ = *x_;
+        }
+
+        void readState(double dt) override {
+            *x_ = xCheckpoint_;
+        }
+    };
+    /*!
+    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+    */
+    template<class SolutionVector, class GridVariables>
+    class SolverStateGridVar: public SolverStateBase
+    {
+    private:
+        SolutionVector *x_;
+        SolutionVector xCheckpoint_;
+        GridVariables *gv_;
+    public:
+        SolverStateGridVar(SolutionVector &x, GridVariables &gv)
+            : x_(&x), xCheckpoint_(*x_), gv_(&gv)
+        {}
+
+        void writeState() override {
+            xCheckpoint_ = *x_;
+        }
+
+        void readState(double dt) override {
+            *x_ = xCheckpoint_;
+            gv_->update(*x_);
+            gv_->advanceTimeStep();
+        }
+    };
+    /*!
+    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+    */
+    template<class SolutionVector, class TimeLoop, class GridVariables>
+    class SolverStateGridVarTime: public SolverStateBase
+    {
+    private:
+        SolutionVector *x_;
+        SolutionVector xCheckpoint_;
+        TimeLoop *tl_;
+        double timeCheckpoint_{0.0};
+        long timeStepCheckpoint_{0};
+        GridVariables *gv_;
+    public:
+        SolverStateGridVarTime(SolutionVector &x, TimeLoop &tl, GridVariables &gv)
+            : x_(&x), xCheckpoint_(*x_), tl_(&tl), gv_(&gv)
+        {}
+
+        void writeState() override {
+            xCheckpoint_ = *x_;
+            timeCheckpoint_ = tl_->time();
+            timeStepCheckpoint_ = tl_->timeStepIndex();
+        }
+
+        void readState(double dt) override {
+            *x_ = xCheckpoint_;
+            tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
+            tl_->setTimeStepSize(dt);
+            gv_->update(*x_);
+            gv_->advanceTimeStep();
+        }
+    };
+}  // namespace Dumux::Precice
+#endif
+

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -57,7 +57,6 @@ public:
     {
         *x_ = xCheckpoint_;
         gv_->update(*x_);
-        gv_->advanceTimeStep();
     }
 };
 /*!
@@ -93,7 +92,6 @@ public:
         tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
         tl_->setTimeStepSize(dt);
         gv_->update(*x_);
-        gv_->advanceTimeStep();
     }
 };
 }  // namespace Dumux::Precice

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -15,8 +15,8 @@ struct SolverStateBase {
     virtual void readState() = 0;
 };
 /*!
-    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
-    */
+ * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+ */
 template<class SolutionVector>
 class SolverStateOnly : public SolverStateBase
 {
@@ -32,8 +32,8 @@ public:
     void readState() override { *x_ = xCheckpoint_; }
 };
 /*!
-    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
-    */
+ * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+ */
 template<class SolutionVector, class GridVariables>
 class SolverStateGridVar : public SolverStateBase
 {
@@ -57,8 +57,8 @@ public:
     }
 };
 /*!
-    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
-    */
+ * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+ */
 template<class SolutionVector, class GridVariables, class TimeLoop>
 class SolverStateGridVarTimeLoop : public SolverStateBase
 {

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -74,12 +74,19 @@ private:
     long timeStepCheckpoint_ = 0;
 
 public:
-    SolverStateGridVarTimeLoop(SolutionVector &x, GridVariables &gv, TimeLoop &tl)
+    SolverStateGridVarTimeLoop(SolutionVector &x,
+                               GridVariables &gv,
+                               TimeLoop &tl)
         : x_(&x), xCheckpoint_(*x_), gv_(&gv), tl_(&tl)
     {
     }
 
-    void writeState() override { xCheckpoint_ = *x_; timeCheckpoint_ = tl_->time(); timeStepCheckpoint_ = tl_->timeStepIndex(); }
+    void writeState() override
+    {
+        xCheckpoint_ = *x_;
+        timeCheckpoint_ = tl_->time();
+        timeStepCheckpoint_ = tl_->timeStepIndex();
+    }
 
     void readState() override
     {

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -59,5 +59,34 @@ public:
         gv_->update(*x_);
     }
 };
+/*!
+    * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
+    */
+template<class SolutionVector, class GridVariables, class TimeLoop>
+class SolverStateGridVarTimeLoop : public SolverStateBase
+{
+private:
+    SolutionVector *x_;
+    SolutionVector xCheckpoint_;
+    GridVariables *gv_;
+    TimeLoop *tl_;
+    double timeCheckpoint_ = 0.0;
+    long timeStepCheckpoint_ = 0;
+
+public:
+    SolverStateGridVarTimeLoop(SolutionVector &x, GridVariables &gv, TimeLoop &tl)
+        : x_(&x), xCheckpoint_(*x_), gv_(&gv), tl_(&tl)
+    {
+    }
+
+    void writeState() override { xCheckpoint_ = *x_; timeCheckpoint_ = tl_->time(); timeStepCheckpoint_ = tl_->timeStepIndex(); }
+
+    void readState() override
+    {
+        *x_ = xCheckpoint_;
+        gv_->update(*x_);
+        tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
+    }
+};
 }  // namespace Dumux::Precice
 #endif

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -1,10 +1,7 @@
 #ifndef SOLVERSTATE_HH
 #define SOLVERSTATE_HH
 
-#include <dumux/common/properties.hh>
-#include <ostream>
 #include <precice/precice.hpp>
-#include <string>
 
 /*!
  * @brief Namespace of dumux-precice

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -1,10 +1,10 @@
 #ifndef SOLVERSTATE_HH
 #define SOLVERSTATE_HH
 
-#include <ostream>
-#include <string>
-#include <precice/precice.hpp>
 #include <dumux/common/properties.hh>
+#include <ostream>
+#include <precice/precice.hpp>
+#include <string>
 
 /*!
  * @brief Namespace of dumux-precice
@@ -12,90 +12,89 @@
  */
 namespace Dumux::Precice
 {
-    struct SolverStateBase {
-        virtual ~SolverStateBase() = default;
-        virtual void writeState() = 0;
-        virtual void readState(double dt) = 0;
-    };
-    /*!
+struct SolverStateBase {
+    virtual ~SolverStateBase() = default;
+    virtual void writeState() = 0;
+    virtual void readState(double dt) = 0;
+};
+/*!
     * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
     */
-    template<class SolutionVector>
-    class SolverStateOnly: public SolverStateBase
-    {
-    private:
-        SolutionVector *x_;
-        SolutionVector xCheckpoint_;
-    public:
-        SolverStateOnly(SolutionVector &x)
-            : x_(&x), xCheckpoint_(*x_)
-        {}
+template<class SolutionVector>
+class SolverStateOnly : public SolverStateBase
+{
+private:
+    SolutionVector *x_;
+    SolutionVector xCheckpoint_;
 
-        void writeState() override {
-            xCheckpoint_ = *x_;
-        }
+public:
+    SolverStateOnly(SolutionVector &x) : x_(&x), xCheckpoint_(*x_) {}
 
-        void readState(double dt) override {
-            *x_ = xCheckpoint_;
-        }
-    };
-    /*!
+    void writeState() override { xCheckpoint_ = *x_; }
+
+    void readState(double dt) override { *x_ = xCheckpoint_; }
+};
+/*!
     * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
     */
-    template<class SolutionVector, class GridVariables>
-    class SolverStateGridVar: public SolverStateBase
+template<class SolutionVector, class GridVariables>
+class SolverStateGridVar : public SolverStateBase
+{
+private:
+    SolutionVector *x_;
+    SolutionVector xCheckpoint_;
+    GridVariables *gv_;
+
+public:
+    SolverStateGridVar(SolutionVector &x, GridVariables &gv)
+        : x_(&x), xCheckpoint_(*x_), gv_(&gv)
     {
-    private:
-        SolutionVector *x_;
-        SolutionVector xCheckpoint_;
-        GridVariables *gv_;
-    public:
-        SolverStateGridVar(SolutionVector &x, GridVariables &gv)
-            : x_(&x), xCheckpoint_(*x_), gv_(&gv)
-        {}
+    }
 
-        void writeState() override {
-            xCheckpoint_ = *x_;
-        }
+    void writeState() override { xCheckpoint_ = *x_; }
 
-        void readState(double dt) override {
-            *x_ = xCheckpoint_;
-            gv_->update(*x_);
-            gv_->advanceTimeStep();
-        }
-    };
-    /*!
+    void readState(double dt) override
+    {
+        *x_ = xCheckpoint_;
+        gv_->update(*x_);
+        gv_->advanceTimeStep();
+    }
+};
+/*!
     * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
     */
-    template<class SolutionVector, class TimeLoop, class GridVariables>
-    class SolverStateGridVarTime: public SolverStateBase
+template<class SolutionVector, class TimeLoop, class GridVariables>
+class SolverStateGridVarTime : public SolverStateBase
+{
+private:
+    SolutionVector *x_;
+    SolutionVector xCheckpoint_;
+    TimeLoop *tl_;
+    double timeCheckpoint_{0.0};
+    long timeStepCheckpoint_{0};
+    GridVariables *gv_;
+
+public:
+    SolverStateGridVarTime(SolutionVector &x, TimeLoop &tl, GridVariables &gv)
+        : x_(&x), xCheckpoint_(*x_), tl_(&tl), gv_(&gv)
     {
-    private:
-        SolutionVector *x_;
-        SolutionVector xCheckpoint_;
-        TimeLoop *tl_;
-        double timeCheckpoint_{0.0};
-        long timeStepCheckpoint_{0};
-        GridVariables *gv_;
-    public:
-        SolverStateGridVarTime(SolutionVector &x, TimeLoop &tl, GridVariables &gv)
-            : x_(&x), xCheckpoint_(*x_), tl_(&tl), gv_(&gv)
-        {}
+    }
 
-        void writeState() override {
-            xCheckpoint_ = *x_;
-            timeCheckpoint_ = tl_->time();
-            timeStepCheckpoint_ = tl_->timeStepIndex();
-        }
+    void writeState() override
+    {
+        xCheckpoint_ = *x_;
+        timeCheckpoint_ = tl_->time();
+        timeStepCheckpoint_ = tl_->timeStepIndex();
+    }
 
-        void readState(double dt) override {
-            *x_ = xCheckpoint_;
-            tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
-            tl_->setTimeStepSize(dt);
-            gv_->update(*x_);
-            gv_->advanceTimeStep();
-        }
-    };
+    void readState(double dt) override
+    {
+        *x_ = xCheckpoint_;
+        tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
+        tl_->setTimeStepSize(dt);
+        gv_->update(*x_);
+        gv_->advanceTimeStep();
+    }
+};
 }  // namespace Dumux::Precice
 #endif
-

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -15,7 +15,7 @@ namespace Dumux::Precice
 struct SolverStateBase {
     virtual ~SolverStateBase() = default;
     virtual void writeState() = 0;
-    virtual void readState(double dt) = 0;
+    virtual void readState() = 0;
 };
 /*!
     * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
@@ -32,7 +32,7 @@ public:
 
     void writeState() override { xCheckpoint_ = *x_; }
 
-    void readState(double dt) override { *x_ = xCheckpoint_; }
+    void readState() override { *x_ = xCheckpoint_; }
 };
 /*!
     * @brief A class to store and provide the state of the solver while checkpointing, one SolutionVector object is supported.
@@ -53,7 +53,7 @@ public:
 
     void writeState() override { xCheckpoint_ = *x_; }
 
-    void readState(double dt) override
+    void readState() override
     {
         *x_ = xCheckpoint_;
         gv_->update(*x_);

--- a/dumux-precice/solverstate.hh
+++ b/dumux-precice/solverstate.hh
@@ -68,6 +68,7 @@ private:
     GridVariables *gv_;
     TimeLoop *tl_;
     double timeCheckpoint_ = 0.0;
+    double dtCheckpoint_ = 0.0;
     long timeStepCheckpoint_ = 0;
 
 public:
@@ -83,6 +84,7 @@ public:
         xCheckpoint_ = *x_;
         timeCheckpoint_ = tl_->time();
         timeStepCheckpoint_ = tl_->timeStepIndex();
+        dtCheckpoint_ = tl_->timeStepSize();
     }
 
     void readState() override
@@ -90,6 +92,7 @@ public:
         *x_ = xCheckpoint_;
         gv_->update(*x_);
         tl_->setTime(timeCheckpoint_, timeStepCheckpoint_);
+        tl_->setTimeStepSize(dtCheckpoint_);
     }
 };
 }  // namespace Dumux::Precice

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(ff-pm)
 add_subdirectory(dummysolver)
+add_subdirectory(singleCheckpointTest)

--- a/examples/dummysolver/main_dummysolver.cc
+++ b/examples/dummysolver/main_dummysolver.cc
@@ -164,7 +164,7 @@ try {
     int iter = 0;
 
     while (couplingParticipant.isCouplingOngoing()) {
-        if (couplingParticipant.requiresToWriteCheckpoint()) {
+        if (couplingParticipant.writeCheckpointIfRequired()) {
             std::cout << "DUMMY (" << mpiHelper.rank()
                       << "): Writing iteration checkpoint\n";
         }
@@ -244,7 +244,7 @@ try {
         preciceDt = couplingParticipant.getMaxTimeStepSize();
         couplingParticipant.advance(preciceDt);
 
-        if (couplingParticipant.requiresToReadCheckpoint()) {
+        if (couplingParticipant.readCheckpointIfRequired()) {
             std::cout << "DUMMY (" << mpiHelper.rank()
                       << "): Reading iteration checkpoint\n";
         } else {

--- a/examples/ff-pm/main_ff.cc
+++ b/examples/ff-pm/main_ff.cc
@@ -445,6 +445,9 @@ try {
         couplingParticipant.writeQuantityToOtherSolver(meshName, dataNameP);
     }
     couplingParticipant.initialize();
+    couplingParticipant.initializeCheckpoint(sol[momentumIdx],
+                                             *momentumGridVariables);
+    couplingParticipant.initializeCheckpoint(sol[massIdx], *massGridVariables);
 
     // the assembler for a stationary problem
     using Assembler =
@@ -468,16 +471,11 @@ try {
 
     double preciceDt = couplingParticipant.getMaxTimeStepSize();
     auto dt = preciceDt;
-    auto sol_checkpoint = sol;
 
     double vtkTime = 1.0;
-    size_t iter = 0;
 
     while (couplingParticipant.isCouplingOngoing()) {
-        if (couplingParticipant.requiresToWriteCheckpoint()) {
-            //DO CHECKPOINTING
-            sol_checkpoint = sol;
-        }
+        couplingParticipant.writeCheckpointIfRequired();
 
         couplingParticipant.readQuantityFromOtherSolver(meshName, dataNameV,
                                                         dt);
@@ -495,24 +493,13 @@ try {
             momentumProblem, *momentumGridVariables, sol[momentumIdx], meshName,
             dataNameP);
         couplingParticipant.writeQuantityToOtherSolver(meshName, dataNameP);
-        //Read checkpoint
         freeFlowVtkWriter.write(vtkTime);
         vtkTime += 1.;
         couplingParticipant.advance(dt);
         preciceDt = couplingParticipant.getMaxTimeStepSize();
         dt = std::min(preciceDt, dt);
 
-        ++iter;
-
-        if (couplingParticipant.requiresToReadCheckpoint()) {
-            sol = sol_checkpoint;
-            momentumGridVariables->update(sol[momentumIdx]);
-            massGridVariables->update(sol[massIdx]);
-            momentumGridVariables->advanceTimeStep();
-            massGridVariables->advanceTimeStep();
-        } else  // coupling successful
-        {
-            // write vtk output
+        if (!couplingParticipant.readCheckpointIfRequired(dt)) {
             freeFlowVtkWriter.write(vtkTime);
         }
     }

--- a/examples/ff-pm/main_ff.cc
+++ b/examples/ff-pm/main_ff.cc
@@ -499,7 +499,7 @@ try {
         preciceDt = couplingParticipant.getMaxTimeStepSize();
         dt = std::min(preciceDt, dt);
 
-        if (!couplingParticipant.readCheckpointIfRequired(dt)) {
+        if (!couplingParticipant.readCheckpointIfRequired()) {
             freeFlowVtkWriter.write(vtkTime);
         }
     }

--- a/examples/ff-pm/main_pm.cc
+++ b/examples/ff-pm/main_pm.cc
@@ -345,7 +345,9 @@ try {
     auto darcyProblem = std::make_shared<DarcyProblem>(darcyGridGeometry);
 
     // the solution vector
-    GetPropType<DarcyTypeTag, Properties::SolutionVector> sol;
+    using SolutionVector =
+        GetPropType<DarcyTypeTag, Properties::SolutionVector>;
+    SolutionVector sol;
     sol.resize(darcyGridGeometry->numDofs());
 
     // Initialize preCICE.Tell preCICE about:
@@ -436,6 +438,9 @@ try {
     }
     couplingParticipant.initialize();
 
+    //initialize checkpointing
+    couplingParticipant.initializeCheckpoint(sol, *darcyGridVariables);
+
     // the assembler for a stationary problem
     using Assembler = FVAssembler<DarcyTypeTag, DiffMethod::numeric>;
     auto assembler = std::make_shared<Assembler>(
@@ -453,16 +458,11 @@ try {
 
     double preciceDt = couplingParticipant.getMaxTimeStepSize();
     auto dt = preciceDt;
-    auto sol_checkpoint = sol;
 
     double vtkTime = 1.0;
-    size_t iter = 0;
 
     while (couplingParticipant.isCouplingOngoing()) {
-        if (couplingParticipant.requiresToWriteCheckpoint()) {
-            //DO CHECKPOINTING
-            sol_checkpoint = sol;
-        }
+        couplingParticipant.writeCheckpointIfRequired();
 
         couplingParticipant.readQuantityFromOtherSolver(meshName, dataNameP,
                                                         dt);
@@ -485,19 +485,9 @@ try {
         preciceDt = couplingParticipant.getMaxTimeStepSize();
         dt = std::min(preciceDt, dt);
 
-        ++iter;
-
-        if (couplingParticipant.requiresToReadCheckpoint()) {
-            //Read checkpoint
-            darcyVtkWriter.write(vtkTime);
+        darcyVtkWriter.write(vtkTime);
+        if (couplingParticipant.readCheckpointIfRequired(dt)) {
             vtkTime += 1.;
-            sol = sol_checkpoint;
-            darcyGridVariables->update(sol);
-            darcyGridVariables->advanceTimeStep();
-        } else  // coupling successful
-        {
-            // write vtk output
-            darcyVtkWriter.write(vtkTime);
         }
     }
     // write vtk output

--- a/examples/ff-pm/main_pm.cc
+++ b/examples/ff-pm/main_pm.cc
@@ -486,7 +486,7 @@ try {
         dt = std::min(preciceDt, dt);
 
         darcyVtkWriter.write(vtkTime);
-        if (couplingParticipant.readCheckpointIfRequired(dt)) {
+        if (couplingParticipant.readCheckpointIfRequired()) {
             vtkTime += 1.;
         }
     }

--- a/examples/singleCheckpointTest/Allrun.sh
+++ b/examples/singleCheckpointTest/Allrun.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+set -e -u
+
+rm -rf precice-run/
+
+./dumuxprecice_singlecheckpointtest -preCICE.SolverName SolverOne -preCICE.ConfigFileName test.xml -preCICE.MeshName MeshOne > Solver_One.out 2>&1 &
+SOLVER_ONE_ID=$!
+
+./dumuxprecice_singlecheckpointtest -preCICE.SolverName SolverTwo -preCICE.ConfigFileName test.xml -preCICE.MeshName MeshTwo > Solver_Two.out 2>&1 &
+SOLVER_TWO_ID=$!
+
+wait ${SOLVER_ONE_ID}
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+wait ${SOLVER_TWO_ID}
+if [ $? -ne 0 ]; then
+    exit $?
+fi

--- a/examples/singleCheckpointTest/CMakeLists.txt
+++ b/examples/singleCheckpointTest/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(dumuxprecice_singlecheckpointtest EXCLUDE_FROM_ALL main.cc)
+
+dune_symlink_to_source_files(FILES test.xml)
+dune_symlink_to_source_files(FILES Allrun.sh)
+
+dumux_add_test(NAME dumuxprecice_singlecheckpointtest
+              TARGET dumuxprecice_singlecheckpointtest
+              LABELS singlecheckpointtest precice dummy
+              TIMEOUT 30
+              COMMAND Allrun.sh)

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -47,11 +47,9 @@ public:
 // Mock GridVariables class to test checkpointing functionality
 class GridVariables
 {
-public:
     bool updated{false};
-    bool advanced{false};
+public:
     void update(const std::vector<double> & /*x*/) { updated = true; }
-    void advanceTimeStep() { advanced = true; }
 };
 
 int main(int argc, char **argv)
@@ -97,7 +95,6 @@ int main(int argc, char **argv)
 
     std::vector<double> writeScalarData(numberOfVertices);
     std::vector<double> readScalarData(numberOfVertices);
-    std::vector<double> dataToKeep(numberOfVertices);
 
     std::vector<double> vertices(numberOfVertices * dimensions);  // coordinates
     std::vector<int> dumuxVertexIDs(numberOfVertices);
@@ -149,13 +146,20 @@ int main(int argc, char **argv)
     }
 
     int iter = 0;
-    dataToKeep = writeScalarData;
-    double timeToKeep = timeLoop.time();
-    long timeStepIndexToKeep = timeLoop.timeStepIndex();
+    std::vector<double> dataToKeep(numberOfVertices);
+    double timeToKeep = 0.0;
+    long timeStepIndexToKeep = 0;
+    double timeStepSizeToKeep = 0.0;
 
     while (couplingParticipant.isCouplingOngoing()) {
         if (solverName == "SolverOne") {
-            couplingParticipant.writeCheckpointIfRequired();
+            if (couplingParticipant.writeCheckpointIfRequired()) {
+                // Keep data for later comparison
+                dataToKeep = writeScalarData;
+                timeToKeep = timeLoop.time();
+                timeStepIndexToKeep = timeLoop.timeStepIndex();
+                timeStepSizeToKeep = timeLoop.timeStepSize();
+            }
 
             ++iter;
 
@@ -164,20 +168,20 @@ int main(int argc, char **argv)
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);
             timeLoop.advanceTime(preciceDt);
-            if (!couplingParticipant.readCheckpointIfRequired()) {
-                timeToKeep = timeLoop.time();
-                timeStepIndexToKeep = timeLoop.timeStepIndex();
-            }
-            if (writeScalarData != dataToKeep) {
-                throw std::runtime_error(
-                    "SolverOne: Checkpointing failed, data not restored "
-                    "correctly");
-            }
-            if ((timeStepIndexToKeep != timeLoop.timeStepIndex()) ||
-                (timeToKeep != timeLoop.time())) {
-                throw std::runtime_error(
-                    "SolverOne: Checkpointing failed, time step not "
-                    "restored correctly");
+            timeLoop.setTimeStepSize(preciceDt/2.);
+            if (couplingParticipant.readCheckpointIfRequired()) {
+                if (writeScalarData != dataToKeep) {
+                    throw std::runtime_error(
+                        "SolverOne: Checkpointing failed, data not restored "
+                        "correctly");
+                }
+                if ((timeStepIndexToKeep != timeLoop.timeStepIndex()) ||
+                    (timeToKeep != timeLoop.time()) ||
+                    (timeStepSizeToKeep != timeLoop.timeStepSize())) {
+                    throw std::runtime_error(
+                        "SolverOne: Checkpointing failed, time step not "
+                        "restored correctly");
+                }
             }
         } else {
             couplingParticipant.writeCheckpointIfRequired();

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -10,8 +10,6 @@
 #include <iostream>
 
 #include <dune/common/parallel/mpihelper.hh>
-#include <dune/common/timer.hh>
-#include <dune/istl/io.hh>
 
 #include <dumux/common/dumuxmessage.hh>
 #include <dumux/common/parameters.hh>

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -24,14 +24,17 @@ class TimeLoop
 {
 private:
     double currentTime_{0.0};
+    double currentDt_{0.0};
     long currentStep_{0};
 
 public:
     double time() const { return currentTime_; }
     long timeStepIndex() const { return currentStep_; }
+    double timeStepSize() const { return currentDt_; }
     void advanceTime(double dt)
     {
         currentTime_ += dt;
+        currentDt_ = dt;
         ++currentStep_;
     }
     void setTime(double time, long step)
@@ -39,6 +42,7 @@ public:
         currentTime_ = time;
         currentStep_ = step;
     }
+    void setTimeStepSize(double dt) { currentDt_ = dt; }
 };
 // Mock GridVariables class to test checkpointing functionality
 class GridVariables

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);
-            couplingParticipant.readCheckpointIfRequired(preciceDt);
+            couplingParticipant.readCheckpointIfRequired();
             if (writeScalarData != dataToKeep) {
                 throw std::runtime_error(
                     "SolverOne: Checkpointing failed, data not restored "
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
             couplingParticipant.writeCheckpointIfRequired();
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);
-            couplingParticipant.readCheckpointIfRequired(preciceDt);
+            couplingParticipant.readCheckpointIfRequired();
         }
     }
     ////////////////////////////////////////////////////////////

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -48,6 +48,7 @@ public:
 class GridVariables
 {
     bool updated{false};
+
 public:
     void update(const std::vector<double> & /*x*/) { updated = true; }
 };
@@ -168,7 +169,7 @@ int main(int argc, char **argv)
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);
             timeLoop.advanceTime(preciceDt);
-            timeLoop.setTimeStepSize(preciceDt/2.);
+            timeLoop.setTimeStepSize(preciceDt / 2.);
             if (couplingParticipant.readCheckpointIfRequired()) {
                 if (writeScalarData != dataToKeep) {
                     throw std::runtime_error(

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -19,29 +19,34 @@
 #include "dumux-precice/couplingadapter.hh"
 
 #include <memory>
-#include <type_traits>
 #include <numeric>
+#include <type_traits>
 
 // Mock TimeLoop class to test checkpointing functionality
-class TimeLoop {
-    public:
+class TimeLoop
+{
+public:
     double t{0.0};
     long idx{0};
     double time() const { return t; }
     long timeStepIndex() const { return idx; }
-    void setTime(double tt, long i) { t = tt; idx = i; }
+    void setTime(double tt, long i)
+    {
+        t = tt;
+        idx = i;
+    }
     void setTimeStepSize(double /*dt*/) {}
 };
 
 // Mock GridVariables class to test checkpointing functionality
-class GridVariables {
-    public:
+class GridVariables
+{
+public:
     bool updated{false};
     bool advanced{false};
     void update(const std::vector<double> & /*x*/) { updated = true; }
     void advanceTimeStep() { advanced = true; }
 };
-
 
 int main(int argc, char **argv)
 try {
@@ -96,7 +101,8 @@ try {
     std::iota(dumuxVertexIDs.begin(), dumuxVertexIDs.end(), numberOfVertices);
     // set vertex coordinates: for each vertex i fill its `dimensions` entries with i
     for (int i = 0; i < numberOfVertices; ++i) {
-        std::fill_n(vertices.begin() + i * dimensions, dimensions, static_cast<double>(i));
+        std::fill_n(vertices.begin() + i * dimensions, dimensions,
+                    static_cast<double>(i));
     }
 
     std::cout << "DUMMY (" << mpiHelper.rank()
@@ -115,8 +121,7 @@ try {
                   << "): Writing initial data\n";
         couplingParticipant.writeQuantityVector(meshName, dataToWrite,
                                                 writeScalarData);
-        couplingParticipant.writeQuantityToOtherSolver(meshName,
-                                                       dataToWrite);
+        couplingParticipant.writeQuantityToOtherSolver(meshName, dataToWrite);
     }
     std::cout << "DUMMY (" << mpiHelper.rank() << "): Exchange initial\n";
     couplingParticipant.initialize();
@@ -129,20 +134,21 @@ try {
     GridVariables gridVars;
 
     // Register writeScalarData as the solver state for checkpointing.
-    couplingParticipant.initializeCheckpoint(writeScalarData, timeLoop, gridVars);
+    couplingParticipant.initializeCheckpoint(writeScalarData, timeLoop,
+                                             gridVars);
 
     // Check exchanged initial data
     if (solverName == "SolverOne") {
         std::cout << "SolverOne: Reading initial data\n";
-        couplingParticipant.readQuantityFromOtherSolver(
-            meshName, dataToRead, preciceDt);
+        couplingParticipant.readQuantityFromOtherSolver(meshName, dataToRead,
+                                                        preciceDt);
     }
 
     int iter = 0;
     dataToKeep = writeScalarData;
 
     while (couplingParticipant.isCouplingOngoing()) {
-        if(solverName=="SolverOne") {
+        if (solverName == "SolverOne") {
             couplingParticipant.writeCheckpointIfRequired();
 
             ++iter;
@@ -153,11 +159,11 @@ try {
             couplingParticipant.advance(preciceDt);
             couplingParticipant.readCheckpointIfRequired(preciceDt);
             if (writeScalarData != dataToKeep) {
-                throw std::runtime_error("SolverOne: Checkpointing failed, data not restored correctly");
+                throw std::runtime_error(
+                    "SolverOne: Checkpointing failed, data not restored "
+                    "correctly");
             }
-        }
-        else
-        {
+        } else {
             couplingParticipant.writeCheckpointIfRequired();
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -27,6 +27,7 @@ class TimeLoop
 private:
     double currentTime_{0.0};
     long currentStep_{0};
+
 public:
     double time() const { return currentTime_; }
     long timeStepIndex() const { return currentStep_; }
@@ -136,7 +137,7 @@ int main(int argc, char **argv)
 
     // Register writeScalarData as the solver state for checkpointing.
     couplingParticipant.initializeCheckpoint(writeScalarData, gridVars,
-                                                 timeLoop);
+                                             timeLoop);
 
     // Check exchanged initial data
     if (solverName == "SolverOne") {
@@ -163,13 +164,15 @@ int main(int argc, char **argv)
             timeLoop.advanceTime(preciceDt);
             if (!couplingParticipant.readCheckpointIfRequired()) {
                 timeToKeep = timeLoop.time();
-                timeStepIndexToKeep = timeLoop.timeStepIndex();}
+                timeStepIndexToKeep = timeLoop.timeStepIndex();
+            }
             if (writeScalarData != dataToKeep) {
                 throw std::runtime_error(
                     "SolverOne: Checkpointing failed, data not restored "
                     "correctly");
             }
-            if ((timeStepIndexToKeep != timeLoop.timeStepIndex()) || (timeToKeep != timeLoop.time())) {
+            if ((timeStepIndexToKeep != timeLoop.timeStepIndex()) ||
+                (timeToKeep != timeLoop.time())) {
                 throw std::runtime_error(
                     "SolverOne: Checkpointing failed, time step not "
                     "restored correctly");

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -22,22 +22,6 @@
 #include <numeric>
 #include <type_traits>
 
-// Mock TimeLoop class to test checkpointing functionality
-class TimeLoop
-{
-public:
-    double t{0.0};
-    long idx{0};
-    double time() const { return t; }
-    long timeStepIndex() const { return idx; }
-    void setTime(double tt, long i)
-    {
-        t = tt;
-        idx = i;
-    }
-    void setTimeStepSize(double /*dt*/) {}
-};
-
 // Mock GridVariables class to test checkpointing functionality
 class GridVariables
 {
@@ -49,7 +33,7 @@ public:
 };
 
 int main(int argc, char **argv)
-try {
+{
     using namespace Dumux;
     // initialize MPI, finalize is done automatically on exit
     const auto &mpiHelper = Dune::MPIHelper::instance(argc, argv);
@@ -127,15 +111,11 @@ try {
     couplingParticipant.initialize();
     double preciceDt = 0;
 
-    // Create instances of the file-scope mock types and register them for
-    // checkpointing. Types are declared in the anonymous namespace above so
-    // template instantiation will see their definitions.
-    TimeLoop timeLoop;
+    // Create instances of the file-scope mock types for checkpointing.
     GridVariables gridVars;
 
     // Register writeScalarData as the solver state for checkpointing.
-    couplingParticipant.initializeCheckpoint(writeScalarData, timeLoop,
-                                             gridVars);
+    couplingParticipant.initializeCheckpoint(writeScalarData, gridVars);
 
     // Check exchanged initial data
     if (solverName == "SolverOne") {
@@ -186,17 +166,3 @@ try {
 
     return 0;
 }  // end main
-// namespace
-catch (Dumux::ParameterException &e) {
-    std::cerr << std::endl << e << " ---> Abort!" << std::endl;
-    return 1;
-} catch (Dune::Exception &e) {
-    std::cerr << "Dune reported error: " << e << " ---> Abort!" << std::endl;
-    return 3;
-} catch (std::runtime_error &e) {
-    std::cerr << std::endl << e.what() << " ---> Abort!" << std::endl;
-    return 4;
-} catch (...) {
-    std::cerr << "Unknown exception thrown! ---> Abort!" << std::endl;
-    return 5;
-}

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -22,6 +22,25 @@
 #include <numeric>
 #include <type_traits>
 
+class TimeLoop
+{
+private:
+    double currentTime_{0.0};
+    long currentStep_{0};
+public:
+    double time() const { return currentTime_; }
+    long timeStepIndex() const { return currentStep_; }
+    void advanceTime(double dt)
+    {
+        currentTime_ += dt;
+        ++currentStep_;
+    }
+    void setTime(double time, long step)
+    {
+        currentTime_ = time;
+        currentStep_ = step;
+    }
+};
 // Mock GridVariables class to test checkpointing functionality
 class GridVariables
 {
@@ -113,9 +132,11 @@ int main(int argc, char **argv)
 
     // Create instances of the file-scope mock types for checkpointing.
     GridVariables gridVars;
+    TimeLoop timeLoop;
 
     // Register writeScalarData as the solver state for checkpointing.
-    couplingParticipant.initializeCheckpoint(writeScalarData, gridVars);
+    couplingParticipant.initializeCheckpoint(writeScalarData, gridVars,
+                                                 timeLoop);
 
     // Check exchanged initial data
     if (solverName == "SolverOne") {
@@ -126,6 +147,8 @@ int main(int argc, char **argv)
 
     int iter = 0;
     dataToKeep = writeScalarData;
+    double timeToKeep = timeLoop.time();
+    long timeStepIndexToKeep = timeLoop.timeStepIndex();
 
     while (couplingParticipant.isCouplingOngoing()) {
         if (solverName == "SolverOne") {
@@ -137,11 +160,19 @@ int main(int argc, char **argv)
 
             preciceDt = couplingParticipant.getMaxTimeStepSize();
             couplingParticipant.advance(preciceDt);
-            couplingParticipant.readCheckpointIfRequired();
+            timeLoop.advanceTime(preciceDt);
+            if (!couplingParticipant.readCheckpointIfRequired()) {
+                timeToKeep = timeLoop.time();
+                timeStepIndexToKeep = timeLoop.timeStepIndex();}
             if (writeScalarData != dataToKeep) {
                 throw std::runtime_error(
                     "SolverOne: Checkpointing failed, data not restored "
                     "correctly");
+            }
+            if ((timeStepIndexToKeep != timeLoop.timeStepIndex()) || (timeToKeep != timeLoop.time())) {
+                throw std::runtime_error(
+                    "SolverOne: Checkpointing failed, time step not "
+                    "restored correctly");
             }
         } else {
             couplingParticipant.writeCheckpointIfRequired();

--- a/examples/singleCheckpointTest/main.cc
+++ b/examples/singleCheckpointTest/main.cc
@@ -1,0 +1,196 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*!
+ * \file TODO
+ *
+ * \brief TODO
+ */
+#include <config.h>
+
+#include <iostream>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <dune/common/timer.hh>
+#include <dune/istl/io.hh>
+
+#include <dumux/common/dumuxmessage.hh>
+#include <dumux/common/parameters.hh>
+
+#include "dumux-precice/couplingadapter.hh"
+
+#include <memory>
+#include <type_traits>
+#include <numeric>
+
+// Mock TimeLoop class to test checkpointing functionality
+class TimeLoop {
+    public:
+    double t{0.0};
+    long idx{0};
+    double time() const { return t; }
+    long timeStepIndex() const { return idx; }
+    void setTime(double tt, long i) { t = tt; idx = i; }
+    void setTimeStepSize(double /*dt*/) {}
+};
+
+// Mock GridVariables class to test checkpointing functionality
+class GridVariables {
+    public:
+    bool updated{false};
+    bool advanced{false};
+    void update(const std::vector<double> & /*x*/) { updated = true; }
+    void advanceTimeStep() { advanced = true; }
+};
+
+
+int main(int argc, char **argv)
+try {
+    using namespace Dumux;
+    // initialize MPI, finalize is done automatically on exit
+    const auto &mpiHelper = Dune::MPIHelper::instance(argc, argv);
+
+    // print dumux start message
+    if (mpiHelper.rank() == 0)
+        DumuxMessage::print(/*firstCall=*/true);
+
+    // parse command line arguments and input file
+    Parameters::init(argc, argv);
+
+    // Initialize preCICE. Tell preCICE about:
+    // - Name of solver
+    // - Configuration file name
+    // - Solver rank
+    const std::string solverName =
+        getParamFromGroup<std::string>("preCICE", "SolverName");
+    const std::string preciceConfigFilename =
+        getParamFromGroup<std::string>("preCICE", "ConfigFileName");
+    const std::string meshName =
+        getParamFromGroup<std::string>("preCICE", "MeshName");
+
+    auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
+    couplingParticipant.announceSolver(solverName, preciceConfigFilename,
+                                       mpiHelper.rank(), mpiHelper.size());
+    std::cout << "DUMMY (" << mpiHelper.rank()
+              << "): Running solver dummy with preCICE config file \""
+              << preciceConfigFilename << "\", participant name \""
+              << solverName << "\", and mesh name \"" << meshName << "\".\n";
+
+    const int dimensions = couplingParticipant.getMeshDimensions(meshName);
+    assert(dimensions == 3);
+    const std::string dataToWrite =
+        (solverName == "SolverOne") ? "dataOne" : "dataTwo";
+    const std::string dataToRead =
+        (solverName == "SolverOne") ? "dataTwo" : "dataOne";
+
+    const int numberOfVertices = 3;
+
+    std::vector<double> writeScalarData(numberOfVertices);
+    std::vector<double> readScalarData(numberOfVertices);
+    std::vector<double> dataToKeep(numberOfVertices);
+
+    std::vector<double> vertices(numberOfVertices * dimensions);  // coordinates
+    std::vector<int> dumuxVertexIDs(numberOfVertices);
+
+    // initialize writeScalarData and dumuxVertexIDs with consecutive values
+    std::iota(writeScalarData.begin(), writeScalarData.end(), numberOfVertices);
+    std::iota(dumuxVertexIDs.begin(), dumuxVertexIDs.end(), numberOfVertices);
+    // set vertex coordinates: for each vertex i fill its `dimensions` entries with i
+    for (int i = 0; i < numberOfVertices; ++i) {
+        std::fill_n(vertices.begin() + i * dimensions, dimensions, static_cast<double>(i));
+    }
+
+    std::cout << "DUMMY (" << mpiHelper.rank()
+              << "): Initialize preCICE and set mesh\n";
+    couplingParticipant.setMesh(meshName, vertices);
+
+    // Create index mapping between DuMuX's index numbering and preCICE's numbering
+    std::cout << "DUMMY (" << mpiHelper.rank() << "): Create index mapping\n";
+    couplingParticipant.createIndexMapping(dumuxVertexIDs);
+
+    couplingParticipant.announceQuantity(meshName, dataToWrite);
+    couplingParticipant.announceQuantity(meshName, dataToRead);
+
+    if (couplingParticipant.requiresToWriteInitialData()) {
+        std::cout << "DUMMY (" << mpiHelper.rank()
+                  << "): Writing initial data\n";
+        couplingParticipant.writeQuantityVector(meshName, dataToWrite,
+                                                writeScalarData);
+        couplingParticipant.writeQuantityToOtherSolver(meshName,
+                                                       dataToWrite);
+    }
+    std::cout << "DUMMY (" << mpiHelper.rank() << "): Exchange initial\n";
+    couplingParticipant.initialize();
+    double preciceDt = 0;
+
+    // Create instances of the file-scope mock types and register them for
+    // checkpointing. Types are declared in the anonymous namespace above so
+    // template instantiation will see their definitions.
+    TimeLoop timeLoop;
+    GridVariables gridVars;
+
+    // Register writeScalarData as the solver state for checkpointing.
+    couplingParticipant.initializeCheckpoint(writeScalarData, timeLoop, gridVars);
+
+    // Check exchanged initial data
+    if (solverName == "SolverOne") {
+        std::cout << "SolverOne: Reading initial data\n";
+        couplingParticipant.readQuantityFromOtherSolver(
+            meshName, dataToRead, preciceDt);
+    }
+
+    int iter = 0;
+    dataToKeep = writeScalarData;
+
+    while (couplingParticipant.isCouplingOngoing()) {
+        if(solverName=="SolverOne") {
+            couplingParticipant.writeCheckpointIfRequired();
+
+            ++iter;
+
+            std::iota(writeScalarData.begin(), writeScalarData.end(), iter);
+
+            preciceDt = couplingParticipant.getMaxTimeStepSize();
+            couplingParticipant.advance(preciceDt);
+            couplingParticipant.readCheckpointIfRequired(preciceDt);
+            if (writeScalarData != dataToKeep) {
+                throw std::runtime_error("SolverOne: Checkpointing failed, data not restored correctly");
+            }
+        }
+        else
+        {
+            couplingParticipant.writeCheckpointIfRequired();
+            preciceDt = couplingParticipant.getMaxTimeStepSize();
+            couplingParticipant.advance(preciceDt);
+            couplingParticipant.readCheckpointIfRequired(preciceDt);
+        }
+    }
+    ////////////////////////////////////////////////////////////
+    // finalize, print dumux message to say goodbye
+    ////////////////////////////////////////////////////////////
+
+    couplingParticipant.finalize();
+    std::cout << "DUMMY (" << mpiHelper.rank()
+              << "): Closing single checkpoint test.\n";
+
+    // print dumux end message
+    if (mpiHelper.rank() == 0) {
+        Parameters::print();
+        DumuxMessage::print(/*firstCall=*/false);
+    }
+
+    return 0;
+}  // end main
+// namespace
+catch (Dumux::ParameterException &e) {
+    std::cerr << std::endl << e << " ---> Abort!" << std::endl;
+    return 1;
+} catch (Dune::Exception &e) {
+    std::cerr << "Dune reported error: " << e << " ---> Abort!" << std::endl;
+    return 3;
+} catch (std::runtime_error &e) {
+    std::cerr << std::endl << e.what() << " ---> Abort!" << std::endl;
+    return 4;
+} catch (...) {
+    std::cerr << "Unknown exception thrown! ---> Abort!" << std::endl;
+    return 5;
+}

--- a/examples/singleCheckpointTest/test.xml
+++ b/examples/singleCheckpointTest/test.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="dataOne" />
+  <data:vector name="dataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="dataOne" />
+    <use-data name="dataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="dataOne" />
+    <use-data name="dataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="dataOne" mesh="MeshOne" />
+    <read-data name="dataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="dataTwo" mesh="MeshTwo" />
+    <read-data name="dataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" exchange-directory=".." />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <max-iterations value="3" />
+    <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="dataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/examples/singleCheckpointTest/test.xml
+++ b/examples/singleCheckpointTest/test.xml
@@ -49,7 +49,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="2" />
     <time-window-size value="1.0" />
     <max-iterations value="3" />
     <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />


### PR DESCRIPTION
## Description
To close https://github.com/precice/dumux-adapter/issues/56.
Different initialization option for checkpointing is provided to match the need of different cases in `examples/` and the [heat-conduction case](https://github.com/precice/tutorials/blob/develop/two-scale-heat-conduction/macro-dumux/appl/main.cc) .
## Checklist
- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
- [ ] I updated the documentation.
- [x] I added a test for the new feature.
