### PR TITLE
Add `isTimeWindowComplete` API function wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # DuMuX-preCICE change log
 
 ## latest
+
+- Added `isTimeWindowComplete` API function wrapper [#62](https://github.com/precice/dumux-adapter/pull/62)
 - Updated docker recipe to make preCICE version name consistent [#59](https://github.com/precice/dumux-adapter/pull/59)
 - Added dumux-customised checkpointing feature [#58](https://github.com/precice/dumux-adapter/pull/58)
 - Improved ID lookup from `log(n)` to constant where n is the mesh size [#44](https://github.com/precice/dumux-adapter/pull/44)

--- a/dumux-precice/couplingadapter.cc
+++ b/dumux-precice/couplingadapter.cc
@@ -106,6 +106,12 @@ bool CouplingAdapter::isCouplingOngoing()
     return precice_->isCouplingOngoing();
 }
 
+bool CouplingAdapter::isTimeWindowComplete()
+{
+    assert(wasCreated_);
+    return precice_->isTimeWindowComplete();
+}
+
 size_t CouplingAdapter::getNumberOfVertices()
 {
     assert(wasCreated_);

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -212,8 +212,8 @@ public:
     /*!
      * @brief Checks whether the time window has completed.
      *
-     * @return true Coupling is still ongoing.
-     * @return false Coupling finished.
+     * @return true Time window has completed.
+     * @return false Time window is still ongoing.
      */
     bool isTimeWindowComplete();
     /*!

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -210,6 +210,13 @@ public:
      */
     bool isCouplingOngoing();
     /*!
+     * @brief Checks whether the coupling is still ongoing.
+     *
+     * @return true Coupling is still ongoing.
+     * @return false Coupling finished.
+     */
+    bool isTimeWindowComplete();
+    /*!
      * @brief Get the number of vertices on the coupling interface.
      *
      * @return size_t Number of vertices on the coupling interface.

--- a/dumux-precice/couplingadapter.hh
+++ b/dumux-precice/couplingadapter.hh
@@ -210,7 +210,7 @@ public:
      */
     bool isCouplingOngoing();
     /*!
-     * @brief Checks whether the coupling is still ongoing.
+     * @brief Checks whether the time window has completed.
      *
      * @return true Coupling is still ongoing.
      * @return false Coupling finished.


### PR DESCRIPTION
## Description

The preCICE API function `isTimeWindowComplete` is essential for checking whether the current time window has been completed. It is helpful for a user of the adapter to be able to call it. Whether this API call can be incorporated into the adapter's existing functions is an open question.

## Checklist

<!--
Please make sure to go over all points on the checklist and
mark them as checked.
-->

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
- [ ] I updated the documentation.

<!--
If the pull request adds new content, please check the points
below. Otherwise remove the following lines.
-->

- [ ] I added a test for the new feature.
