### PR TITLE
Add system tests workflow

### DIFF
--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "Pull request number: [${{ github.event.number }}](https://github.com/precice/dumux-adapter/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
           echo "### Micro-Manager" >> $GITHUB_STEP_SUMMARY
-          echo "Using v0.8.0 (pinned)."
+          echo "Using v0.8.0 (pinned)." >> $GITHUB_STEP_SUMMARY
           echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
           echo "Reference (develop): [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -1,0 +1,47 @@
+name: System tests
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  gather-refs:
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    runs-on: ubuntu-latest
+    outputs:
+      ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
+    steps:
+      - id: ref-tutorials
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: tutorials
+          branch: develop
+      - id: report-refs
+        name: Report Git refs
+        run: |
+          printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}\n ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
+      - id: summary
+        name: Prepare Markdown summary
+        run: |
+          echo "### DuMux adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request number: [${{ github.event.number }}](https://github.com/precice/dumux-adapter/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
+          echo "### Micro-Manager" >> $GITHUB_STEP_SUMMARY
+          echo "Using v0.8.0 (pinned)."
+          echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
+          echo "Reference (develop): [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-tutorials.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  run-system-tests:
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    needs: gather-refs
+    uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
+    with:
+      suites: dumux_adapter_pr
+      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},MICRO_MANAGER_REF:v0.8.0,DUMUX_ADAPTER_PR:${{ github.event.number }},DUMUX_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
+      system_tests_branch: develop
+      log_level: "DEBUG"

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -41,7 +41,7 @@ jobs:
     needs: gather-refs
     uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
     with:
-      suites: dumux_adapter_pr
+      suites: dumux_test
       build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},MICRO_MANAGER_REF:v0.8.0,DUMUX_ADAPTER_PR:${{ github.event.number }},DUMUX_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
       system_tests_branch: develop
       log_level: "DEBUG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # DuMuX-preCICE change log
 
+- Added a system tests workflow [#80](https://github.com/precice/dumux-adapter/pull/80)
 - Remove additional clang-format check and merge python formatting into pre-commit [#76](https://github.com/precice/dumux-adapter/pull/76)
 - Add adapter configuration reader for configuration via `.input` file [#68](https://github.com/precice/dumux-adapter/pull/68)
 


### PR DESCRIPTION
## Description

Adds a system tests workflow that would allow triggering the system tests with labeling a PR, similarly to the tutorials and the `openfoam-adapter` repositories.

I pinned the Micro-Manager version to v0.8.0, to avoid testing two components at the same time, but also communicating in the workflow that this is needed. For the rest, default values are being picked up from the `components.yml`.

TODO:

- [x] Create the label (I can do that)
- [x] Enable the runner for this repo (see [runner groups](https://github.com/organizations/precice/settings/actions/runner-groups))
- [x] Run the tests ([triggered](https://github.com/precice/dumux-adapter/actions/runs/23786280959?pr=80), fails for the two-scale-heat-conduction [as discussed](https://github.com/precice/tutorials/pull/758#issuecomment-4160498433))

## Checklist

- [x] I made sure that the source files are formatted properly.
- [x] I added my changes to the changelog (`CHANGELOG.md`)
- ~~I updated the documentation.~~ Not sure if anything is needed.