### PR TITLE
Bump base Docker image to ubuntu:24.04

### DIFF
--- a/.github/workflows/build-docker-containers.yml
+++ b/.github/workflows/build-docker-containers.yml
@@ -38,7 +38,7 @@ jobs:
           tags: ${{ env.dockerhub_username }}/dumux-precice:${{ matrix.dumux_version }}-${{ matrix.precice_version }}
           build-args: |
             DUNEVERSION=2.9
-            PRECICEUBUNTU=jammy
+            PRECICEUBUNTU=noble
             DUMUXVERSION=${{ matrix.dumux_version }}
             PRECICEVERSION=${{ matrix.precice_version }}
   build-dune-precice:
@@ -69,5 +69,5 @@ jobs:
           tags: ${{ env.dockerhub_username }}/dune-precice:${{ matrix.dune_version }}-${{ matrix.precice_version }}
           build-args: |
             DUNEVERSION=${{ matrix.dune_version }}
-            PRECICEUBUNTU=jammy
+            PRECICEUBUNTU=noble
             PRECICEVERSION=${{ matrix.precice_version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 project(dumux-precice CXX)
-# We require version CMake version 3.1 to prevent issues
-# with dune_enable_all_packages and older CMake versions.
 cmake_minimum_required(VERSION 3.13)
 
 if(NOT (dune-common_DIR

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ The versions of the main dependencies can be manipulated when building the Docke
 - `ARG DUNEVERSION=2.9`: DUNE version. Available in all recipes.
 - `ARG DUMUXVERSION=3.7`: DuMuX version. Available in all recipes.
 - `ARG PRECICEVERSION=3.0.0`: preCICE version. Available only in "large" and "slim" (use name e.g. "3.0.0" for branch `v3.0.0` or "develop" for branch `develop`) recipes.
-- `ARG PRECICEUBUNTU=jammy`: preCICE target platform (here, Ubuntu Jammy Jellyfish). Available only in "large" recipe.
+- `ARG PRECICEUBUNTU=noble`: preCICE target platform (here, Ubuntu Noble Numbat). Available only in "large" recipe.
 
 If one wants to build a "slim" image using DUNE 2.9, DuMuX from the current master branch and preCICE 3.0.0 one could call it with the following command:
 

--- a/docker/dockerfile.base
+++ b/docker/dockerfile.base
@@ -1,6 +1,6 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Prohibit /usr/doc files from being installed
 ADD 01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
@@ -21,13 +21,13 @@ RUN bash checkout_repositories.sh ${DUNEVERSION} ${DUMUXVERSION}
 # Install DUNE and DUMUX
 COPY cmake-test.opts .
 # Make dunecontrol available
-ENV PATH /opt/DUMUX/dune-common/bin:${PATH}
+ENV PATH=/opt/DUMUX/dune-common/bin:${PATH}
 RUN dunecontrol --opts=cmake-test.opts all
 
 # Make DUNE and DUMUX accessible
 ENV DUNE_CONTROL_PATH=${DUMUXINSTALLPATH}/dune-common/dune.module:${DUMUXINSTALLPATH}/dune-geometry/dune.module:${DUMUXINSTALLPATH}/dune-grid/dune.module:${DUMUXINSTALLPATH}/dune-localfunctions/dune.module:${DUMUXINSTALLPATH}/dune-istl/dune.module:${DUMUXINSTALLPATH}/dune-subgrid/dune.module:${DUMUXINSTALLPATH}/dumux/dune.module
 
-ENV PYTHONPATH ${DUMUXINSTALLPATH}/dumux/bin/testing:${PYTHONPATH}
+ENV PYTHONPATH=${DUMUXINSTALLPATH}/dumux/bin/testing
 
 # Cleanup
 RUN apt-get autoremove -y && apt-get clean

--- a/docker/dockerfile.large
+++ b/docker/dockerfile.large
@@ -1,9 +1,9 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install DUNE and DuMuX in /home/dumux
 WORKDIR	${USER_HOME}
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Prohibit /usr/doc files from being installed
 ADD 01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
@@ -22,17 +22,17 @@ RUN bash checkout_repositories.sh ${DUNEVERSION} ${DUMUXVERSION}
 # Install DUNE and DUMUX
 COPY cmake-test.opts .
 # Make dunecontrol available
-ENV PATH ${USER_HOME}/dune-common/bin:${PATH}
+ENV PATH=${USER_HOME}/dune-common/bin:${PATH}
 RUN dunecontrol --opts=cmake-test.opts all
 
 # Make DUNE and DUMUX accessible
 ENV DUNE_CONTROL_PATH=${USER_HOME}/dune-common/dune.module:${USER_HOME}/dune-geometry/dune.module:${USER_HOME}/dune-grid/dune.module:${USER_HOME}/dune-localfunctions/dune.module:${USER_HOME}/dune-istl/dune.module:${USER_HOME}/dune-subgrid/dune.module:${USER_HOME}/dumux/dune.module
 
-ENV PYTHONPATH ${USER_HOME}/dumux/bin/testing:${PYTHONPATH}
+ENV PYTHONPATH=${USER_HOME}/dumux/bin/testing:${PYTHONPATH}
 
 #Install preCICE
-ARG PRECICEVERSION=3.0.0
-ARG PRECICEUBUNTU=jammy
+ARG PRECICEVERSION=3.4.1
+ARG PRECICEUBUNTU=noble
 RUN wget https://github.com/precice/precice/releases/download/v${PRECICEVERSION}/libprecice3_${PRECICEVERSION}_${PRECICEUBUNTU}.deb -O libprecice${PRECICEVERSION}-${PRECICEUBUNTU}.deb \
 	&& apt install -y ./libprecice${PRECICEVERSION}-${PRECICEUBUNTU}.deb \
 	&& rm -f ./libprecice${PRECICEVERSION}-${PRECICEUBUNTU}.deb

--- a/docker/dockerfile.slim
+++ b/docker/dockerfile.slim
@@ -1,13 +1,13 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Prohibit /usr/doc files from being installed
 ADD 01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
 
 # Install dependencies from
 RUN apt-get update
-RUN apt-get install -y git gcc g++ gfortran cmake pkg-config libboost-log1.74.0 libboost-thread1.74.0 libboost-system1.74.0 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-test1.74.0 libboost-container1.74.0 libeigen3-dev libxml2 libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libeigen3-dev libxml2-dev libsuitesparse-dev python3
+RUN apt-get install -y git gcc g++ gfortran cmake pkg-config libboost-log1.83.0 libboost-thread1.83.0 libboost-system1.83.0 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-test1.83.0 libboost-container1.83.0 libeigen3-dev libxml2 libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libeigen3-dev libxml2-dev libsuitesparse-dev python3
 
 ARG DUMUXINSTALLPATH=/opt/DUMUX
 WORKDIR ${DUMUXINSTALLPATH}
@@ -21,16 +21,16 @@ RUN bash checkout_repositories.sh ${DUNEVERSION} ${DUMUXVERSION}
 # Install DUNE and DUMUX
 COPY cmake-test.opts .
 # Make dunecontrol available
-ENV PATH /opt/DUMUX/dune-common/bin:${PATH}
+ENV PATH=/opt/DUMUX/dune-common/bin:${PATH}
 RUN dunecontrol --opts=cmake-test.opts all
 
 # Make DUNE and DUMUX accessible
 ENV DUNE_CONTROL_PATH=${DUMUXINSTALLPATH}/dune-common/dune.module:${DUMUXINSTALLPATH}/dune-geometry/dune.module:${DUMUXINSTALLPATH}/dune-grid/dune.module:${DUMUXINSTALLPATH}/dune-localfunctions/dune.module:${DUMUXINSTALLPATH}/dune-istl/dune.module:${DUMUXINSTALLPATH}/dune-subgrid/dune.module:${DUMUXINSTALLPATH}/dumux/dune.module
 
-ENV PYTHONPATH ${DUMUXINSTALLPATH}/dumux/bin/testing:${PYTHONPATH}
+ENV PYTHONPATH=${DUMUXINSTALLPATH}/dumux/bin/testing
 
 # Compile minmum version of preCICE
-ARG PRECICEVERSION=3.0.0
+ARG PRECICEVERSION=3.4.1
 ARG PRECICEBRANCH=${PRECICEVERSION}
 RUN bash -c 'if [[ "$PRECICEVERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then PRECICEBRANCH="v${PRECICEVERSION}"; fi;\
     git clone --depth 1 -b ${PRECICEBRANCH} https://github.com/precice/precice.git precice-${PRECICEBRANCH} && cd precice-${PRECICEBRANCH} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEBRANCH}'

--- a/docker/dockerfile_dune-precice.slim
+++ b/docker/dockerfile_dune-precice.slim
@@ -1,13 +1,13 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Prohibit /usr/doc files from being installed
 ADD 01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
 
 # Install dependencies from
 RUN apt-get update
-RUN apt-get install -y git gcc g++ gfortran cmake pkg-config libboost-log1.74.0 libboost-thread1.74.0 libboost-system1.74.0 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-test1.74.0 libboost-container1.74.0 libeigen3-dev libxml2 libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libeigen3-dev libxml2-dev libsuitesparse-dev python3
+RUN apt-get install -y git gcc g++ gfortran cmake pkg-config libboost-log1.83.0 libboost-thread1.83.0 libboost-system1.83.0 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-test1.83.0 libboost-container1.83.0 libeigen3-dev libxml2 libboost-log-dev libboost-thread-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-test-dev libboost-container-dev libeigen3-dev libxml2-dev libsuitesparse-dev python3
 
 ARG DUMUXINSTALLPATH=/opt/DUMUX
 WORKDIR ${DUMUXINSTALLPATH}
@@ -20,14 +20,14 @@ RUN bash checkout_repositories.sh ${DUNEVERSION} none
 # Install DUNE and DUMUX
 COPY cmake-test.opts .
 # Make dunecontrol available
-ENV PATH /opt/DUMUX/dune-common/bin:${PATH}
+ENV PATH=/opt/DUMUX/dune-common/bin:${PATH}
 RUN dunecontrol --opts=cmake-test.opts all
 
 # Make DUNE and DUMUX accessible
 ENV DUNE_CONTROL_PATH=${DUMUXINSTALLPATH}/dune-common/dune.module:${DUMUXINSTALLPATH}/dune-geometry/dune.module:${DUMUXINSTALLPATH}/dune-grid/dune.module:${DUMUXINSTALLPATH}/dune-localfunctions/dune.module:${DUMUXINSTALLPATH}/dune-istl/dune.module:${DUMUXINSTALLPATH}/dune-subgrid/dune.module
 
 # Compile minmum version of preCICE
-ARG PRECICEVERSION=3.0.0
+ARG PRECICEVERSION=3.4.1
 ARG PRECICEBRANCH=${PRECICEVERSION}
 RUN bash -c 'if [[ "$PRECICEVERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then PRECICEBRANCH="v${PRECICEVERSION}"; fi;\
     git clone --depth 1 -b ${PRECICEBRANCH} https://github.com/precice/precice.git precice-${PRECICEBRANCH} && cd precice-${PRECICEBRANCH} && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_INSTALL_PREFIX=/usr && make -j 4 && make test && make install && cd ../../ && rm -rf precice-${PRECICEBRANCH}'


### PR DESCRIPTION
## Description

Fixes #83

- Changes the base image used in the Dockerfiles to Ubuntu 24.04, since the baseline in preCICE recently changed.
- Fixes a few warnings in the Dockerfiles related to environment variables.
- Changes the default preCICE version in the Dockerfiles from 3.0.0 to the current 3.4.1
- Removes an outdated comment in the `CMakeLists.txt` (triggered by the original issue)

I have checked that all the Dockerfiles build successfully. Where preCICE is used, `precice-version` works.

There are still a few aspects that could be improved, but I would leave them for another PR:

- The base image could be directly upgraded to Ubuntu 26.04.
- I think the Dockerfiles are more complicated than necessary. In particular, I am wondering how much space is being saved by removing the `-dev` packages.
- I am not sure if I understand why all of these different Dockerfiles are needed. There is some duplication among them.
- The DUNE/DuMux versions seem to be inconsistent / outdated.

## Checklist

- [x] I made sure that the source files are formatted properly.
- I added my changes to the changelog (`CHANGELOG.md`) -> N/A
- I updated the documentation. -> N/A