### PR TITLE
Update and cleanup pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,26 @@
 repos:
-  # Official repo for default hooks
-  - repo: https://github.com/precice/precice-pre-commit-hooks
-    rev: "v3.3"
-    hooks:
-      - id: format-precice-config
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.30.0
-    hooks:
-      - id: markdownlint
-        exclude: "CHANGELOG.md|.github/*"
-      - id: markdownlint-fix
-        exclude: "CHANGELOG.md|.github/*"
-  # clang-format for C/C++ formatting
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.2
-    hooks:
-      - id: clang-format
-        args: ["--style=file"]
-        types_or: [c++]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
       - id: check-xml
       - id: check-merge-conflict
       - id: mixed-line-ending
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  # black repo for python formatting
-  - repo: https://github.com/ambv/black
-    rev: 25.1.0
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.5
     hooks:
-      - id: black
-        name: format python
+      - id: clang-format
+        args: ["--style=file"]
+        types_or: [c++]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.0
+    hooks:
+      - id: markdownlint
+        files: "^docs/.*.md"
+      - id: markdownlint-fix
+        files: "^docs/.*.md"
+  - repo: https://github.com/precice/precice-pre-commit-hooks
+    rev: "v3.3"
+    hooks:
+      - id: format-precice-config


### PR DESCRIPTION
## Description

This is just a maintenance PR. It:

- Removes black from the pre-commit hooks, since there are no Python files in this repository (to save some setup time).
- Updates the hooks:
   - `pre-commit-hooks` from v2.3.0 -> v6.0.0
   - `clang-format` from v19.1.2 -> v22.1.5 (no formatting changes)
   - `markdownlint-cli` from v0.30.0 -> v0.49.0
- For `markdownlint-cli`, it fixes the coniguration, which was previously raising a warning: Instead of trying to exclude specific files, it only includes files in `docs/`.
- Orders the hooks from more general to more specific (base pre-commit -> C++ formatting -> Markdown formatting -> preCICE config formatting).

## Checklist

- [x] I made sure that the source files are formatted properly.
- I added my changes to the changelog (`CHANGELOG.md`) -> Not needed.
- I updated the documentation. -> Not needed.